### PR TITLE
fix(sails.sockets.leave): dont throw error if null is passed

### DIFF
--- a/lib/sails.sockets/leave-room.js
+++ b/lib/sails.sockets/leave-room.js
@@ -21,7 +21,7 @@ module.exports = function(app) {
 
     _.each(sockets, function(socket) {
       // If a string was sent, try to look up a socket with that ID
-      if (typeof socket !== 'object') {
+      if (typeof socket !== 'object' && socket !== null) {
         socket = app.sockets.get(socket+'');
       }
 

--- a/test/sails.sockets.test.js
+++ b/test/sails.sockets.test.js
@@ -262,6 +262,11 @@ describe('low-level socket methods:', function (){
         });
       });
     });
+    it('should warn and not error if passing in null socket', function(done) {
+      // Testing fix for #6
+      sails.sockets.leave(null);
+      done();
+    });
   });
 
 
@@ -610,4 +615,3 @@ function _getSocketId(clientSocket, cb){
     return cb(null, jwr.body);
   });
 }
-


### PR DESCRIPTION
Fixes #6.

I was passing null into sockets.leave, which passed the typeof == 'object' check, which caused app.sockets.get to be called on null, which threw an error.

Now it will properly continue with a log.warn when passing in null to sockets.leave.
