### PR TITLE
Add validation on db parameter in adapter config

### DIFF
--- a/lib/prepare-adapter.js
+++ b/lib/prepare-adapter.js
@@ -89,6 +89,7 @@ module.exports = function (app){
             var redisClientConnectionError;
             var pubReady;
             var subReady;
+            var db;
             adapterConfig.pubClient.once('ready', function (){
               if (pubReady) return;
               pubReady = true;
@@ -136,9 +137,16 @@ module.exports = function (app){
               return cb();
             }
 
-            // if `db` was supplied, call `select` on that redis database
-            adapterConfig.pubClient.select(adapterConfig.db, function() {
-              adapterConfig.subClient.select(adapterConfig.db, function (){
+            // if `db` was supplied, validate the value
+            db = parseInt(adapterConfig.db, 10);
+            if(isNaN(db) || db > 15 || db < 0){
+               db = 0;
+               sails.log.warn('socket.io-redis db adapter paramter must be a number between 0 and 15');
+               sails.log.warn('Falling back to database 0');
+            }
+            // then call `select` on that redis database
+            adapterConfig.pubClient.select(db, function() {
+              adapterConfig.subClient.select(db, function (){
                 return cb();
               });
             });

--- a/lib/prepare-adapter.js
+++ b/lib/prepare-adapter.js
@@ -141,7 +141,7 @@ module.exports = function (app){
             db = parseInt(adapterConfig.db, 10);
             if(isNaN(db) || db > 15 || db < 0){
                db = 0;
-               sails.log.warn('socket.io-redis db adapter paramter must be a number between 0 and 15');
+               sails.log.warn('socket.io-redis db adapter parameter must be a number between 0 and 15');
                sails.log.warn('Falling back to database 0');
             }
             // then call `select` on that redis database


### PR DESCRIPTION
When running "sails new", the socket.io-redis adapter config/sockets.js file has the value of `"sails"`.  If the user were to use this setting by simply uncommenting that line, then the subClient.select and the pubClient.select silently fail (the errors are not being monitored).  

The only valid databases that redis has are indices 0 to 15.  This pull request adds validation on the db parameter to prevent the silent failure.
