### PR TITLE
Array to Object-conversion bugfix

### DIFF
--- a/lib/receive-incoming-sails-io-msg.js
+++ b/lib/receive-incoming-sails-io-msg.js
@@ -91,7 +91,7 @@ module.exports = function ToReceiveIncomingSailsIOMsg(app) {
 
       // Attached data becomes simulated HTTP body (`req.body`)
       // (allow `params` or `data` to be specified for backwards/sideways-compatibility)
-      body    : _.extend({}, options.incomingSailsIOMsg.params || {}, options.incomingSailsIOMsg.data || {}),
+      body    : _.isArray(options.incomingSailsIOMsg.data) ? options.incomingSailsIOMsg.data : _.extend({}, options.incomingSailsIOMsg.params || {}, options.incomingSailsIOMsg.data || {}),
 
       // Allow optional headers
       headers: _.defaults({

--- a/test/integration/hook.pubsub.modelEvents.subscribers.test.js
+++ b/test/integration/hook.pubsub.modelEvents.subscribers.test.js
@@ -1,0 +1,30 @@
+var assert = require('assert');
+var util = require('util');
+
+describe('when posting json arrays', function () {
+
+  it('should be able to send and receive it as an array', function (done) {
+    var postData = [{
+      id: 7,
+      firstName: 'Jimmy',
+      lastName: 'Findingo'
+    },{
+      id: 8,
+      firstName: 'Fanny',
+      lastName: 'Findingo'
+    }];
+
+    sails.router.bind('POST /arrays', function (req, res) {
+      assert.equal(Array.isArray(req.body), true, 'req.body should be an array \nFull req.body:'+util.inspect(req.body, false, null), "==");
+      res.send([{success: "finally!"}]);
+    });
+
+    io.socket.post('/arrays', postData, function (data, jwr) {
+      assert.equal(jwr.statusCode, 200, 'Expected 200 status code but got '+jwr.statusCode+'\nFull JWR:'+util.inspect(jwr, false, null));
+      assert.equal(Array.isArray(data), true, 'response data should be an array \nFull data:'+util.inspect(data, false, null), "==");
+      done();
+    });
+
+
+  })
+});


### PR DESCRIPTION
Fixes the bug where an array that is ”posted” to Sails over an socket
connection gets converted to an object.

Se issue https://github.com/balderdashy/sails/issues/2977
