### PR TITLE
Test with Node v4 on Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - "0.10"
   - "0.12"
-  - "iojs-v1"
-  - "iojs-v2"
-before_script: sudo redis-server /etc/redis/redis.conf --port 6380 --requirepass 'secret'
+  - "4"
+services: redis-server
+
+sudo: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+# Run tests in Docker `docker-compose up` on node latest
+# - install node deps first `docker-compose run hook npm install`
+hook:
+  image: node:latest
+  command: npm test
+  volumes:
+    - ./:/usr/src/app
+  working_dir: /usr/src/app
+  environment:
+    - REDIS_HOST=redis
+  links:
+    - redis
+
+redis:
+  image: redis:latest
+  ports:
+    - "6379"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "socket.io-redis": "^0.1.4"
   },
   "scripts": {
-    "test": "node ./node_modules/mocha/bin/mocha --timeout 5000"
+    "test": "node ./node_modules/mocha/bin/mocha --timeout 5000",
+    "docker-test": "docker-compose up # runs `npm test` inside a docker container",
+    "docker-install": "docker-compose run hook npm install # runs `npm install` inside the container"
   },
   "main": "index.js",
   "repository": {

--- a/test/helpers/lifecycle.helper.js
+++ b/test/helpers/lifecycle.helper.js
@@ -20,6 +20,9 @@ module.exports = {
 
   setup: function (done) {
 
+    // prevent async from maxing out EventEmitter's max listeners, defaults to 10
+    process.EventEmitter.defaultMaxListeners = 0;
+
     // New up an instance of Sails and lift it.
     var app = Sails();
 

--- a/test/with-redis.bus.test.js
+++ b/test/with-redis.bus.test.js
@@ -28,13 +28,7 @@ describe('with redis -- bus', function (){
     sockets: {
       adapter: 'socket.io-redis',
       adapterModule: SocketIORedisAdapter,
-
-      // Configure port to match .travis.yml
-      port: 6380,
-
-      // Configure password to match .travis.yml
-      pass: 'secret',
-
+      host: process.env.REDIS_HOST || 'localhost'
     },
 
     routes: {
@@ -48,7 +42,6 @@ describe('with redis -- bus', function (){
         req._sails.hooks.sockets.blastAdminMessage('blast', 123);
         return res.send();
       }
-
     }
   };
 

--- a/test/with-redis.test.js
+++ b/test/with-redis.test.js
@@ -33,15 +33,7 @@ describe('with redis', function (){
     sockets: {
       adapter: 'socket.io-redis',
       adapterModule: SocketIORedisAdapter,
-
-      // Configure port to match .travis.yml
-      port: 6380,
-
-      // Test advanced redis config: (will cause sockets hook to build raw redis clients):
-      //
-      // Configure password to match .travis.yml
-      pass: 'secret',
-      // db: 'sails'
+      host: process.env.REDIS_HOST || 'localhost'
     },
 
     routes: {
@@ -159,7 +151,7 @@ describe('with redis', function (){
 
 
 
-describe('with redis', function (){
+describe('with redis (raw client)', function (){
 
   // Common app config
   var appConfig = {
@@ -178,15 +170,8 @@ describe('with redis', function (){
     sockets: {
       adapter: 'socket.io-redis',
       adapterModule: SocketIORedisAdapter,
-
-      // Configure port to match .travis.yml
-      // port: 6379,
-
       // Test advanced redis config: (will cause sockets hook to build raw redis clients):
-      url: 'redis://:secret@localhost:6380'
-      // Configure password to match .travis.yml
-      // pass: 'secret',
-      // db: 'sails'
+      url: 'redis://:@' + (process.env.REDIS_HOST || 'localhost') + ':6379'
     },
 
     routes: {


### PR DESCRIPTION
Test with Node v4 on Docker
- Added docker-compose.yml to support testing locally with latest node and redis
- Improve Travis config to use faster test server, and use default redis service

> NOTE: MUST have a semi-recent version of Docker installed with Docker-Compose to make this work.

Do this to get it going:

``` sh
$ docker-compose run hook bash
> npm install
> npm test
```

or, run at any time (after npm install) with:

``` sh
$ docker-compose run hook npm test
```
