### PR TITLE
Fix module load on new NPM versions.

### DIFF
--- a/lib/prepare-adapter.js
+++ b/lib/prepare-adapter.js
@@ -53,8 +53,12 @@ module.exports = function (app){
           try {
             redis = require(path.resolve(pathToAdapterDependency, 'node_modules/redis'));
           }
-          catch (e){
-            return cb(e);
+          catch (e) {
+            try {
+              redis = require('redis');
+            } catch (e) {
+              return cb(e);
+            }
           }
 
           // Set up object that will be used for redis client options


### PR DESCRIPTION
Redis module no longer in `socket.io-redis/node_modules/redis` on new NPM, now just `require('redis')`
