### PR TITLE
Fixed sockets.origins not being passed to socket server creation

### DIFF
--- a/lib/initialize.js
+++ b/lib/initialize.js
@@ -91,6 +91,9 @@ module.exports = function ToInitialize(app) {
         if (app.config.sockets.cookie) {
           opts.cookie = app.config.sockets.cookie;
         }
+        if (app.config.sockets.origins) {
+          opts.origins = app.config.sockets.origins;
+        }
         return opts;
       })());
 


### PR DESCRIPTION
Fixes origins in sockets.js not being passed to SocketIO server creation

[https://github.com/balderdashy/sails/issues/3603](https://github.com/balderdashy/sails/issues/3603)
