### PR TITLE
Upgrade from vulnerable version of socket.io

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lodash": "3.10.1",
     "machinepack-urls": "^3.1.1",
     "semver": "4.3.6",
-    "socket.io": "1.4.8",
+    "socket.io": "^1.5.1",
     "uid2": "0.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
`socket.io@1.4.8` has a vulnerable version of `ws` in its dependency tree. Specifically, that is version `1.1.0` which has a DOS vulnerability.

ref: https://snyk.io/vuln/npm:ws:20160624

This commit upgrades to `socket.io@^1.5.1` which in turn upgrades us to `ws@1.1.1`.