### PR TITLE
[Fixes Sails#4201] Repair req.ip for Socket

### DIFF
--- a/lib/receive-incoming-sails-io-msg.js
+++ b/lib/receive-incoming-sails-io-msg.js
@@ -66,7 +66,8 @@ module.exports = function ToReceiveIncomingSailsIOMsg(app) {
       app.log.silly('Unable to parse IP / port using x-forwarded-for header');
     }
 
-    ips = forwardedFor.length > 0 ? forwardedFor : [options.socket.handshake.address];
+    // Concat the socket address since it's the last proxy address
+    ips = forwardedFor.length > 0 ? forwardedFor.concat([options.socket.handshake.address]) : [options.socket.handshake.address];
 
 
     // Start building up the request context which we'll pass into the interpreter in Sails core:

--- a/lib/receive-incoming-sails-io-msg.js
+++ b/lib/receive-incoming-sails-io-msg.js
@@ -52,25 +52,7 @@ module.exports = function ToReceiveIncomingSailsIOMsg(app) {
     // No more backwards-compatibility for clients < v0.11.0
     if (!semver.satisfies(sdk.version, '>=0.11.0')) {
       return respondWithParseError(util.format('Sails v0.11.x is not compatible with the socket.io/sails.io.js client SDK version you are using (%s). Please see the v0.11 migration guide on http://sailsjs.org for more information.',sdk.version));
-    }
-
-
-    // Use heuristic to guess forwarded ip:port (using `x-forwarded-for` header if IIS)
-    var ip;
-    var port;
-    var forwardedFor;
-    try {
-      // Checks if we trust proxy from the express config
-      forwardedFor = app.hooks.http.app.settings['trust proxy'] ? options.socket.handshake.headers['x-forwarded-for'] : ''; 
-      forwardedFor = forwardedFor.split(':');
-    }
-    catch (e) {
-      app.log.silly('Unable to parse IP / port using x-forwarded-for header');
-    }
-
-    ip = forwardedFor[0] || options.socket.handshake.address;
-    port = forwardedFor[1]; // Only available through proxy header
-    
+    }    
 
     // Start building up the request context which we'll pass into the interpreter in Sails core:
     var requestContext = {
@@ -81,9 +63,9 @@ module.exports = function ToReceiveIncomingSailsIOMsg(app) {
 
       isSocket: true,
 
-      ip      : ip,
+      ip      : options.socket.handshake.address,
 
-      port    : port,
+      port    : null,
 
       // Access to underlying SIO socket
       socket  : options.socket,

--- a/lib/receive-incoming-sails-io-msg.js
+++ b/lib/receive-incoming-sails-io-msg.js
@@ -7,6 +7,7 @@ var _ = require('@sailshq/lodash');
 var semver = require('semver');
 var parseSdkMetadata = require('./parse-sdk-metadata');
 var ERRORPACK = require('./errors');
+var proxyaddr = require('proxy-addr');
 
 /**
  * @required  {Object} app
@@ -54,22 +55,29 @@ module.exports = function ToReceiveIncomingSailsIOMsg(app) {
       return respondWithParseError(util.format('Sails v0.11.x is not compatible with the socket.io/sails.io.js client SDK version you are using (%s). Please see the v0.11 migration guide on http://sailsjs.org for more information.',sdk.version));
     }    
     
-    // Use heuristic to guess forwarded ip using `x-forwarded-for` header
-    var ips;
-    var forwardedFor
+    // Try to get the express 'trust proxy' setting value
+    var expressTrust;
     try {
-      // Checks if we trust proxy from the express config, ip can be spoofed otherwise
-      forwardedFor = app.hooks.http.app.settings['trust proxy'] ? options.socket.handshake.headers['x-forwarded-for'].replace(/\s/g,'') : ''; 
-      forwardedFor = forwardedFor.split(',').length > 1 ? forwardedFor.split(',') : forwardedFor === '' ? [] : [forwardedFor];
+      expressTrust = app.hooks.http.app.get('trust proxy fn');
     }
+    // Something went wrong while retrieving the express settings. Default's to no Trust
     catch (e) {
-      app.log.silly('Unable to parse IP / port using x-forwarded-for header');
-      forwardedFor = [];
+      expressTrust = function () { return false };
     }
+    
+    // Dummy express req object so we can use proxy-addr
+    var reqDummy = {
+      connection: { remoteAddress: options.socket.handshake.address },
+      headers: options.socket.handshake.headers 
+    };
+    
+    var ip = proxyaddr(reqDummy, expressTrust);
+    
+    var ips = proxyaddr.all(reqDummy, expressTrust);
 
-    // Concat the socket address since it's the last proxy address
-    ips = forwardedFor.length > 0 ? forwardedFor.concat([options.socket.handshake.address]) : [options.socket.handshake.address];
-
+    // reverse the order (to farthest -> closest)
+    // and remove socket address
+    ips.reverse().pop();
 
     // Start building up the request context which we'll pass into the interpreter in Sails core:
     var requestContext = {
@@ -80,7 +88,7 @@ module.exports = function ToReceiveIncomingSailsIOMsg(app) {
 
       isSocket: true,
 
-      ip      : ips[0],
+      ip      : ip,
       
       ips     : ips,
 

--- a/lib/receive-incoming-sails-io-msg.js
+++ b/lib/receive-incoming-sails-io-msg.js
@@ -53,6 +53,21 @@ module.exports = function ToReceiveIncomingSailsIOMsg(app) {
     if (!semver.satisfies(sdk.version, '>=0.11.0')) {
       return respondWithParseError(util.format('Sails v0.11.x is not compatible with the socket.io/sails.io.js client SDK version you are using (%s). Please see the v0.11 migration guide on http://sailsjs.org for more information.',sdk.version));
     }    
+    
+    // Use heuristic to guess forwarded ip using `x-forwarded-for` header
+    var ips;
+    var forwardedFor;
+    try {
+      // Checks if we trust proxy from the express config, ip can be spoofed otherwise
+      forwardedFor = app.hooks.http.app.settings['trust proxy'] ? options.socket.handshake.headers['x-forwarded-for'].replace(/\s/g,'') : ''; 
+      forwardedFor = forwardedFor.split(',').length > 1 ? forwardedFor.split(',') : forwardedFor === '' ? [] : [forwardedFor];
+    }
+    catch (e) {
+      app.log.silly('Unable to parse IP / port using x-forwarded-for header');
+    }
+
+    ips = forwardedFor.length > 0 ? forwardedFor : [options.socket.handshake.address];
+
 
     // Start building up the request context which we'll pass into the interpreter in Sails core:
     var requestContext = {
@@ -63,7 +78,9 @@ module.exports = function ToReceiveIncomingSailsIOMsg(app) {
 
       isSocket: true,
 
-      ip      : options.socket.handshake.address,
+      ip      : ips[0],
+      
+      ips     : ips,
 
       port    : null,
 

--- a/lib/receive-incoming-sails-io-msg.js
+++ b/lib/receive-incoming-sails-io-msg.js
@@ -56,7 +56,7 @@ module.exports = function ToReceiveIncomingSailsIOMsg(app) {
     
     // Use heuristic to guess forwarded ip using `x-forwarded-for` header
     var ips;
-    var forwardedFor;
+    var forwardedFor
     try {
       // Checks if we trust proxy from the express config, ip can be spoofed otherwise
       forwardedFor = app.hooks.http.app.settings['trust proxy'] ? options.socket.handshake.headers['x-forwarded-for'].replace(/\s/g,'') : ''; 
@@ -64,6 +64,7 @@ module.exports = function ToReceiveIncomingSailsIOMsg(app) {
     }
     catch (e) {
       app.log.silly('Unable to parse IP / port using x-forwarded-for header');
+      forwardedFor = [];
     }
 
     // Concat the socket address since it's the last proxy address

--- a/lib/receive-incoming-sails-io-msg.js
+++ b/lib/receive-incoming-sails-io-msg.js
@@ -58,16 +58,19 @@ module.exports = function ToReceiveIncomingSailsIOMsg(app) {
     // Use heuristic to guess forwarded ip:port (using `x-forwarded-for` header if IIS)
     var ip;
     var port;
+    var forwardedFor;
     try {
-      var forwardedFor = options.socket.handshake.headers['x-forwarded-for'];
-      forwardedFor = forwardedFor && forwardedFor.split(':') || [];
-      ip = forwardedFor[0] || (options.socket.handshake.address && options.socket.handshake.address.address);
-      port = forwardedFor[1] || (options.socket.handshake.address && options.socket.handshake.address.port);
+      // Checks if we trust proxy from the express config
+      forwardedFor = app.hooks.http.app.settings['trust proxy'] ? options.socket.handshake.headers['x-forwarded-for'] : ''; 
+      forwardedFor = forwardedFor.split(':');
     }
     catch (e) {
       app.log.silly('Unable to parse IP / port using x-forwarded-for header');
     }
 
+    ip = forwardedFor[0] || options.socket.handshake.address;
+    port = forwardedFor[1]; // Only available through proxy header
+    
 
     // Start building up the request context which we'll pass into the interpreter in Sails core:
     var requestContext = {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "machinepack-fs": "^3.0.0",
     "machinepack-http": "^2.1.2",
     "mocha": "3.1.0",
+    "proxy-addr": "1.1.5",
     "redis": "2.6.3",
     "sails": "^1.0.0-12",
     "sails.io.js": "^1.0.0",


### PR DESCRIPTION
Also changed the implementation to get the ips from the 'x-forwarded-for' header to prevent spoofing.