### PR TITLE
Generate new sid cookie if cookie exists but does not contain sid

### DIFF
--- a/lib/load-session-from-socket.js
+++ b/lib/load-session-from-socket.js
@@ -43,7 +43,14 @@ module.exports = function loadSessionFromSocket(socketHandshake, app, cb) {
   if (!socketHandshake.headers.cookie || !cookieHasSailsSid){
     hadToGenerateCookie = true;
     oneTimeCookie = app.session.generateNewSidCookie();
-    socketHandshake.headers.cookie = [socketHandshake.headers.cookie, oneTimeCookie].filter(Boolean).join('; ');
+
+    // If non-sid cookie exists then just append the one-time cookie
+    if (socketHandshake.headers.cookie) {
+      socketHandshake.headers.cookie += '; ' + oneTimeCookie;
+    }
+    else {
+      socketHandshake.headers.cookie = oneTimeCookie;
+    }
 
     // Display a warning in verbose mode if a connection was made without a cookie.
     app.log.verbose(

--- a/lib/load-session-from-socket.js
+++ b/lib/load-session-from-socket.js
@@ -29,11 +29,12 @@ module.exports = function loadSessionFromSocket(socketHandshake, app, cb) {
 
 
   // If no cookie exists, generate one and set it on the handshake
-  var hadToGenerateCookie;
+  var hadToGenerateCookie,
+    oneTimeCookie;
   // Check if there is no cookie, or a cookie is present and it doesn't have sails.sid
   if (!socketHandshake.headers.cookie || ('string' === typeof socketHandshake.headers.cookie &&
     !~socketHandshake.headers.cookie.indexOf(app.config.session && app.config.session.name || 'sails.sid'))){
-    var oneTimeCookie = app.session.generateNewSidCookie();
+    oneTimeCookie = app.session.generateNewSidCookie();
 
     socketHandshake.headers.cookie = [socketHandshake.headers.cookie, oneTimeCookie].filter(Boolean).join('; ') ;
     hadToGenerateCookie = true;

--- a/lib/load-session-from-socket.js
+++ b/lib/load-session-from-socket.js
@@ -41,10 +41,10 @@ module.exports = function loadSessionFromSocket(socketHandshake, app, cb) {
     )
   );
   if (!socketHandshake.headers.cookie || !cookieHasSailsSid){
-    oneTimeCookie = app.session.generateNewSidCookie();
-
-    socketHandshake.headers.cookie = [socketHandshake.headers.cookie, oneTimeCookie].filter(Boolean).join('; ') ;
     hadToGenerateCookie = true;
+    oneTimeCookie = app.session.generateNewSidCookie();
+    socketHandshake.headers.cookie = [socketHandshake.headers.cookie, oneTimeCookie].filter(Boolean).join('; ');
+
     // Display a warning in verbose mode if a connection was made without a cookie.
     app.log.verbose(
       'Could not fetch session, since connecting socket has no cookie in its handshake.'+'\n'+

--- a/lib/load-session-from-socket.js
+++ b/lib/load-session-from-socket.js
@@ -28,12 +28,19 @@ module.exports = function loadSessionFromSocket(socketHandshake, app, cb) {
   }
 
 
-  // If no cookie exists, generate one and set it on the handshake
-  var hadToGenerateCookie,
-    oneTimeCookie;
+  // If no cookie exists, generate one and set it on the handshake.
+  var hadToGenerateCookie;
+  var oneTimeCookie;
   // Check if there is no cookie, or a cookie is present and it doesn't have sails.sid
-  if (!socketHandshake.headers.cookie || ('string' === typeof socketHandshake.headers.cookie &&
-    !~socketHandshake.headers.cookie.indexOf(app.config.session && app.config.session.name || 'sails.sid'))){
+  var cookieHasSailsSid = (
+    'string' === typeof socketHandshake.headers.cookie &&
+    (
+      app.config.session &&
+      'string' === typeof app.config.session.name &&
+      socketHandshake.headers.cookie.indexOf(app.config.session.name)
+    )
+  );
+  if (!socketHandshake.headers.cookie || !cookieHasSailsSid){
     oneTimeCookie = app.session.generateNewSidCookie();
 
     socketHandshake.headers.cookie = [socketHandshake.headers.cookie, oneTimeCookie].filter(Boolean).join('; ') ;

--- a/lib/load-session-from-socket.js
+++ b/lib/load-session-from-socket.js
@@ -30,14 +30,18 @@ module.exports = function loadSessionFromSocket(socketHandshake, app, cb) {
 
   // If no cookie exists, generate one and set it on the handshake
   var hadToGenerateCookie;
-  if (!socketHandshake.headers.cookie){
-    socketHandshake.headers.cookie = app.session.generateNewSidCookie();
+  // Check if there is no cookie, or a cookie is present and it doesn't have sails.sid
+  if (!socketHandshake.headers.cookie || ('string' === typeof socketHandshake.headers.cookie &&
+    !~socketHandshake.headers.cookie.indexOf(app.config.session && app.config.session.name || 'sails.sid'))){
+    var oneTimeCookie = app.session.generateNewSidCookie();
+
+    socketHandshake.headers.cookie = [socketHandshake.headers.cookie, oneTimeCookie].filter(Boolean).join('; ') ;
     hadToGenerateCookie = true;
     // Display a warning in verbose mode if a connection was made without a cookie.
     app.log.verbose(
       'Could not fetch session, since connecting socket has no cookie in its handshake.'+'\n'+
       'Generated a one-time-use cookie:\n'+
-      socketHandshake.headers.cookie+'\n'+
+      oneTimeCookie+'\n'+
       'and saved it on the socket handshake.\n'+
       '\n'+
       '> This means the socket started off with an empty session, i.e. (req.session === {})'+'\n'+


### PR DESCRIPTION
Hi @mikermcneil,

As discussed with @shamasis This PR adds a check for the _configured session name_ cookie
A one-time use cookie will now be generated under two circumstances.
1. There is no cookie present in the handshake header
2. cookies are present in handshake headers, but `sid` cookie is missing.

The new cookie generated will also be appended to the existing cookie instead of replacing it.