### PR TITLE
Upgrade dependencies to resolve potential vulnerabilities & deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,9 @@
 language: node_js
 
 node_js:
-  - "4"
-  - "5"
   - "6"
-  - "7"
   - "8"
+  - "10"
   - "node"
 
 branches:

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ npm install
 To run all the tests, start a local redis server on port 6380 and then run the tests using mocha:
 
 ```sh
-redis-server --port 6380
+redis-server --port 6380 --requirepass 'secret'
 npm test
 ```
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,12 +13,9 @@
 # Test against these versions of Node.js.
 environment:
   matrix:
-    - nodejs_version: "0.10"
-    - nodejs_version: "0.12"
-    - nodejs_version: "4"
-    - nodejs_version: "5"
     - nodejs_version: "6"
-    - nodejs_version: "7"
+    - nodejs_version: "8"
+    - nodejs_version: "10"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -122,7 +122,7 @@ module.exports = function ToConfigure(app) {
       try {
         var parsedUrl = Urls.parse({
           url: app.config.sockets.adapterOptions.url
-        }).execSync();
+        }).now();
         app.config.sockets.adapterOptions.host = parsedUrl.hostname;
         app.config.sockets.adapterOptions.port = parsedUrl.port||0;
         app.config.sockets.adapterOptions.db = parseInt(parsedUrl.path.replace('/', '')) || 0;

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -125,9 +125,9 @@ module.exports = function ToConfigure(app) {
         }).now();
         app.config.sockets.adapterOptions.host = parsedUrl.hostname;
         app.config.sockets.adapterOptions.port = parsedUrl.port||0;
-        app.config.sockets.adapterOptions.db = parseInt(parsedUrl.path.replace('/', '')) || 0;
-        app.config.sockets.adapterOptions.user = parsedUrl.auth.split(':')[0]||undefined;
-        app.config.sockets.adapterOptions.pass = parsedUrl.auth.split(':')[1]||undefined;
+        app.config.sockets.adapterOptions.db = _.isString(parsedUrl.path) ? parseInt(parsedUrl.path.replace('/', '')) : 0;
+        app.config.sockets.adapterOptions.user = _.isString(parsedUrl.auth) ? parsedUrl.auth.split(':')[0] : undefined;
+        app.config.sockets.adapterOptions.pass = _.isString(parsedUrl.auth) ? parsedUrl.auth.split(':')[1] : undefined;
 
       }
       catch (e){

--- a/lib/prepare-driver.js
+++ b/lib/prepare-driver.js
@@ -36,7 +36,7 @@ module.exports = function (app){
     var pathToAdapterDependency = adapterDef.modulePath;
 
     // Create a Redis connection manager
-    var url = adapterConfig.url || Redis.createConnectionUrl(_.pick(adapterConfig, ['host', 'port', 'pass', 'db'])).now();
+    var url = adapterConfig.url || Redis.createConnectionUrl(_.pick(adapterConfig, ['host', 'port', 'pass', 'db'])).execSync();
 
     // Create a Redis connection manager.
     Redis.createManager({
@@ -79,7 +79,7 @@ module.exports = function (app){
         // Use the manager to create a new Redis connection.
         Redis.getConnection({
           manager: createManagerResult.manager,
-        }).switch({
+        }).exec({
           failed: function(err) { return next(err.error); },
           error: next,
           success: function(result) {

--- a/lib/prepare-driver.js
+++ b/lib/prepare-driver.js
@@ -78,7 +78,7 @@ module.exports = function (app){
         Redis.getConnection({
           manager: createManagerResult.manager,
           meta: (adapterConfig[clientName + 'ClientName'] || clientName) + ' ' + app.config.port
-        }).exec({
+        }).switch({
           failed: function(err) { return next(err.error); },
           error: next,
           success: function(result) {

--- a/lib/prepare-driver.js
+++ b/lib/prepare-driver.js
@@ -36,7 +36,7 @@ module.exports = function (app){
     var pathToAdapterDependency = adapterDef.modulePath;
 
     // Create a Redis connection manager
-    var url = adapterConfig.url || Redis.createConnectionUrl(_.pick(adapterConfig, ['host', 'port', 'pass', 'db'])).execSync();
+    var url = adapterConfig.url || Redis.createConnectionUrl(_.pick(adapterConfig, ['host', 'port', 'pass', 'db'])).now();
 
     // Create a Redis connection manager.
     Redis.createManager({
@@ -79,7 +79,7 @@ module.exports = function (app){
         // Use the manager to create a new Redis connection.
         Redis.getConnection({
           manager: createManagerResult.manager,
-        }).exec({
+        }).switch({
           failed: function(err) { return next(err.error); },
           error: next,
           success: function(result) {

--- a/lib/prepare-driver.js
+++ b/lib/prepare-driver.js
@@ -79,7 +79,6 @@ module.exports = function (app){
         // Use the manager to create a new Redis connection.
         Redis.getConnection({
           manager: createManagerResult.manager,
-          meta: (adapterConfig[clientName + 'ClientName'] || clientName) + ' ' + app.config.port// «« TODO: investigate.  This doesn't make sense.  We shouldn't be passing in a string.
         }).switch({
           failed: function(err) { return next(err.error); },
           error: next,

--- a/lib/prepare-driver.js
+++ b/lib/prepare-driver.js
@@ -36,7 +36,7 @@ module.exports = function (app){
     var pathToAdapterDependency = adapterDef.modulePath;
 
     // Create a Redis connection manager
-    var url = adapterConfig.url || Redis.createConnectionUrl(_.pick(adapterConfig, ['host', 'port', 'pass', 'db'])).execSync();
+    var url = adapterConfig.url || Redis.createConnectionUrl(_.pick(adapterConfig, ['host', 'port', 'pass', 'db'])).now();
 
     // Create a Redis connection manager.
     Redis.createManager({

--- a/lib/prepare-driver.js
+++ b/lib/prepare-driver.js
@@ -41,7 +41,7 @@ module.exports = function (app){
     // Create a Redis connection manager.
     Redis.createManager({
       connectionString: url,
-      meta: _.extend({return_buffers: true}, _.omit(adapterConfig, ['host', 'port', 'pass', 'db', 'url'])),
+      meta: _.omit(adapterConfig, ['host', 'port', 'pass', 'db', 'url']),
       // Handle failures on the connection.
       onUnexpectedFailure: function(err) {
         // If Sails is already on the way out, ignore the Redis issue.

--- a/lib/prepare-driver.js
+++ b/lib/prepare-driver.js
@@ -72,7 +72,9 @@ module.exports = function (app){
       async.each(['pub', 'sub'], function (clientName, next) {
 
         // If this client was preconfigured, skip creating it.
-        if (adapterConfig[clientName + 'Client']) { return next(); }
+        if (adapterConfig[clientName + 'Client']) {
+          return next();
+        }
 
         // Use the manager to create a new Redis connection.
         Redis.getConnection({

--- a/lib/prepare-driver.js
+++ b/lib/prepare-driver.js
@@ -79,7 +79,7 @@ module.exports = function (app){
         // Use the manager to create a new Redis connection.
         Redis.getConnection({
           manager: createManagerResult.manager,
-          meta: (adapterConfig[clientName + 'ClientName'] || clientName) + ' ' + app.config.port
+          meta: (adapterConfig[clientName + 'ClientName'] || clientName) + ' ' + app.config.port// «« TODO: investigate.  This doesn't make sense.  We shouldn't be passing in a string.
         }).switch({
           failed: function(err) { return next(err.error); },
           error: next,

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@sailshq/lodash": "^3.10.2",
     "async": "2.0.1",
     "flaverr": "^1.0.0",
-    "machinepack-redis": "^1.3.0",
+    "machinepack-redis": "^2.0.3",
     "machinepack-urls": "^6.0.2-0",
     "proxy-addr": "1.1.5",
     "semver": "4.3.6",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "ioredis": "2.4.0",
     "machinepack-fs": "^3.0.0",
-    "machinepack-http": "^3.1.2",
+    "machinepack-http": "^8.0.0",
     "mocha": "3.1.0",
     "redis": "2.6.3",
     "sails": "^1.0.0-12",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@sailshq/lodash": "^3.10.2",
     "async": "2.0.1",
     "flaverr": "^1.0.0",
-    "machinepack-redis": "^2.0.3",
+    "machinepack-redis": "^1.3.0",
     "machinepack-urls": "^6.0.2-0",
     "proxy-addr": "1.1.5",
     "semver": "4.3.6",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "flaverr": "^1.0.0",
     "machinepack-redis": "^2.0.2",
     "machinepack-urls": "^6.0.2-0",
-    "semver": "4.3.6",
-    "socket.io": "2.0.3",
     "proxy-addr": "1.1.5",
+    "semver": "4.3.6",
+    "socket.io": "2.2.0",
     "uid2": "0.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "async": "2.0.1",
     "flaverr": "^1.0.0",
     "machinepack-redis": "^1.1.1",
-    "machinepack-urls": "^3.1.1",
+    "machinepack-urls": "^6.0.2-0",
     "semver": "4.3.6",
     "socket.io": "2.0.3",
     "proxy-addr": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@sailshq/lodash": "^3.10.2",
     "async": "2.0.1",
     "flaverr": "^1.0.0",
-    "machinepack-redis": "^1.1.1",
+    "machinepack-redis": "^2.0.2",
     "machinepack-urls": "^6.0.2-0",
     "semver": "4.3.6",
     "socket.io": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "ioredis": "2.4.0",
     "machinepack-fs": "^3.0.0",
-    "machinepack-http": "^8.0.0",
+    "machinepack-http": "^3.1.2",
     "mocha": "3.1.0",
     "redis": "2.6.3",
     "sails": "^1.0.0-12",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@sailshq/lodash": "^3.10.2",
     "async": "2.0.1",
     "flaverr": "^1.0.0",
-    "machinepack-redis": "^2.0.2",
+    "machinepack-redis": "^2.0.3",
     "machinepack-urls": "^6.0.2-0",
     "proxy-addr": "1.1.5",
     "semver": "4.3.6",

--- a/test/serve-client.test.js
+++ b/test/serve-client.test.js
@@ -58,8 +58,7 @@ describe('with `serveClient` config enabled', function (){
 
       // Send an HTTP request and receive the response.
       Http.sendHttpRequest({
-        url: '/socket.io/socket.io.js',
-        baseUrl: 'http://localhost:1600',
+        url: 'http://localhost:1600/socket.io/socket.io.js',
         method: 'get'
       }).switch({
         // An unexpected error occurred.
@@ -84,8 +83,7 @@ describe('with `serveClient` config enabled', function (){
 
       // Send an HTTP request and receive the response.
       Http.sendHttpRequest({
-        url: '/socket.io/socket.io.js',
-        baseUrl: 'http://localhost:1601',
+        url: 'http://localhost:1601/socket.io/socket.io.js',
         method: 'get'
       }).switch({
         // An unexpected error occurred.

--- a/test/serve-client.test.js
+++ b/test/serve-client.test.js
@@ -61,7 +61,7 @@ describe('with `serveClient` config enabled', function (){
         url: '/socket.io/socket.io.js',
         baseUrl: 'http://localhost:1600',
         method: 'get'
-      }).switch({
+      }).exec({
         // An unexpected error occurred.
         error: function(err) {
           return done(err);
@@ -87,7 +87,7 @@ describe('with `serveClient` config enabled', function (){
         url: '/socket.io/socket.io.js',
         baseUrl: 'http://localhost:1601',
         method: 'get'
-      }).switch({
+      }).exec({
         // An unexpected error occurred.
         error: function(err) {
           return done(err);

--- a/test/serve-client.test.js
+++ b/test/serve-client.test.js
@@ -61,7 +61,7 @@ describe('with `serveClient` config enabled', function (){
         url: '/socket.io/socket.io.js',
         baseUrl: 'http://localhost:1600',
         method: 'get'
-      }).exec({
+      }).switch({
         // An unexpected error occurred.
         error: function(err) {
           return done(err);
@@ -87,7 +87,7 @@ describe('with `serveClient` config enabled', function (){
         url: '/socket.io/socket.io.js',
         baseUrl: 'http://localhost:1601',
         method: 'get'
-      }).exec({
+      }).switch({
         // An unexpected error occurred.
         error: function(err) {
           return done(err);

--- a/test/with-redis.bus.test.js
+++ b/test/with-redis.bus.test.js
@@ -10,7 +10,7 @@ var Sails = require('sails').Sails;
 var SocketIORedisAdapter = require('socket.io-redis');
 var lifecycle = require('./helpers/lifecycle.helper');
 
-describe('with redis -- bus', function (){
+(require('os').platform() === 'win32' ? describe.skip : describe)('with redis -- bus', function (){
 
   before(lifecycle.setup);
   after(lifecycle.teardown);

--- a/test/with-redis.bus.test.js
+++ b/test/with-redis.bus.test.js
@@ -10,7 +10,7 @@ var Sails = require('sails').Sails;
 var SocketIORedisAdapter = require('socket.io-redis');
 var lifecycle = require('./helpers/lifecycle.helper');
 
-(require('os').platform() === 'win32' ? describe.skip : describe)('with redis -- bus', function (){
+describe('with redis -- bus', function (){
 
   before(lifecycle.setup);
   after(lifecycle.teardown);
@@ -73,7 +73,7 @@ var lifecycle = require('./helpers/lifecycle.helper');
     }, done);
   });
 
-  describe('all apps', function (){
+  (require('os').platform() === 'win32' ? describe.skip : describe)('all apps', function (){
 
     describe('after each app has at least one socket connected', function (){
 

--- a/test/with-redis.bus.test.js
+++ b/test/with-redis.bus.test.js
@@ -10,7 +10,7 @@ var Sails = require('sails').Sails;
 var SocketIORedisAdapter = require('socket.io-redis');
 var lifecycle = require('./helpers/lifecycle.helper');
 
-describe('with redis -- bus', function (){
+(require('os').platform() === 'win32' ? describe.skip : describe)('with redis -- bus', function (){
 
   before(lifecycle.setup);
   after(lifecycle.teardown);
@@ -73,7 +73,7 @@ describe('with redis -- bus', function (){
     }, done);
   });
 
-  (require('os').platform() === 'win32' ? describe.skip : describe)('all apps', function (){
+  describe('all apps', function (){
 
     describe('after each app has at least one socket connected', function (){
 

--- a/test/with-redis.bus.test.js
+++ b/test/with-redis.bus.test.js
@@ -10,7 +10,7 @@ var Sails = require('sails').Sails;
 var SocketIORedisAdapter = require('socket.io-redis');
 var lifecycle = require('./helpers/lifecycle.helper');
 
-(require('os').platform() === 'win32' ? describe.skip : describe)('with redis -- bus', function (){
+describe('with redis -- bus', function (){
 
   before(lifecycle.setup);
   after(lifecycle.teardown);

--- a/test/with-redis.customClients.test.js
+++ b/test/with-redis.customClients.test.js
@@ -12,7 +12,7 @@ var ioredis = require('ioredis');
 var redis = require('redis');
 var lifecycle = require('./helpers/lifecycle.helper');
 
-describe('with redis -- custom clients', function (){
+(require('os').platform() === 'win32' ? describe.skip : describe)('with redis -- custom clients', function (){
 
   var appConfig;
   var pubClient, subClient, adminPubClient, adminSubClient;
@@ -99,7 +99,7 @@ describe('with redis -- custom clients', function (){
     });
   });
 
-  (require('os').platform() === 'win32' ? describe.skip : describe)('all apps', function (){
+  describe('all apps', function (){
 
     describe('after each app has at least one socket connected', function (){
 

--- a/test/with-redis.customClients.test.js
+++ b/test/with-redis.customClients.test.js
@@ -12,7 +12,7 @@ var ioredis = require('ioredis');
 var redis = require('redis');
 var lifecycle = require('./helpers/lifecycle.helper');
 
-(require('os').platform() === 'win32' ? describe.skip : describe)('with redis -- custom clients', function (){
+describe('with redis -- custom clients', function (){
 
   var appConfig;
   var pubClient, subClient, adminPubClient, adminSubClient;
@@ -99,7 +99,7 @@ var lifecycle = require('./helpers/lifecycle.helper');
     });
   });
 
-  describe('all apps', function (){
+  (require('os').platform() === 'win32' ? describe.skip : describe)('all apps', function (){
 
     describe('after each app has at least one socket connected', function (){
 

--- a/test/with-redis.customClients.test.js
+++ b/test/with-redis.customClients.test.js
@@ -12,7 +12,7 @@ var ioredis = require('ioredis');
 var redis = require('redis');
 var lifecycle = require('./helpers/lifecycle.helper');
 
-describe('with redis -- custom clients', function (){
+(require('os').platform() === 'win32' ? describe.skip : describe)('with redis -- custom clients', function (){
 
   var appConfig;
   var pubClient, subClient, adminPubClient, adminSubClient;

--- a/test/with-redis.customClients.test.js
+++ b/test/with-redis.customClients.test.js
@@ -12,7 +12,7 @@ var ioredis = require('ioredis');
 var redis = require('redis');
 var lifecycle = require('./helpers/lifecycle.helper');
 
-(require('os').platform() === 'win32' ? describe.skip : describe)('with redis -- custom clients', function (){
+describe('with redis -- custom clients', function (){
 
   var appConfig;
   var pubClient, subClient, adminPubClient, adminSubClient;

--- a/test/with-redis.errors.test.js
+++ b/test/with-redis.errors.test.js
@@ -210,7 +210,6 @@ describe('with redis -- errors', function (){
         // Configure port to match .travis.yml
         port: 6380,
 
-        // Should fail, because by default Redis only has 16 dbs
         db: 2,
 
       }

--- a/test/with-redis.errors.test.js
+++ b/test/with-redis.errors.test.js
@@ -10,7 +10,7 @@ var Sails = require('sails').Sails;
 var SocketIORedisAdapter = require('socket.io-redis');
 var lifecycle = require('./helpers/lifecycle.helper');
 
-describe('with redis -- errors', function (){
+(require('os').platform() === 'win32' ? describe.skip : describe)('with redis -- errors', function (){
 
   before(lifecycle.setup);
   after(lifecycle.teardown);

--- a/test/with-redis.errors.test.js
+++ b/test/with-redis.errors.test.js
@@ -10,7 +10,7 @@ var Sails = require('sails').Sails;
 var SocketIORedisAdapter = require('socket.io-redis');
 var lifecycle = require('./helpers/lifecycle.helper');
 
-(require('os').platform() === 'win32' ? describe.skip : describe)('with redis -- errors', function (){
+describe('with redis -- errors', function (){
 
   before(lifecycle.setup);
   after(lifecycle.teardown);

--- a/test/with-redis.errors.test.js
+++ b/test/with-redis.errors.test.js
@@ -99,53 +99,53 @@ var lifecycle = require('./helpers/lifecycle.helper');
 
   });
 
-  // Skipping this test for now since apparently Redis allows you to use crazy DB indexes upon connection!
-  // i.e. even if you only have it set up for 16 dbs, you can do redis://localhost:6379/99999, and it will
-  // just silently connect you to db 0 instead.
-  // See: https://github.com/antirez/redis/issues/3410
-  // FUTURE: Check # of available DBs after connection and if its < then the value configured for db, bail
-  // or log a warning.
-  xit('Should fail to lift Sails when attempting to connect with a db value that is > than the # of databases on the Redis server', function(done) {
+  // // Skipping this test for now since apparently Redis allows you to use crazy DB indexes upon connection!
+  // // i.e. even if you only have it set up for 16 dbs, you can do redis://localhost:6379/99999, and it will
+  // // just silently connect you to db 0 instead.
+  // // See: https://github.com/antirez/redis/issues/3410
+  // // FUTURE: Check # of available DBs after connection and if its < then the value configured for db, bail
+  // // or log a warning.
+  // xit('Should fail to lift Sails when attempting to connect with a db value that is > than the # of databases on the Redis server', function(done) {
 
-    Sails().lift({
-      log: { level: 'silent' },
+  //   Sails().lift({
+  //     log: { level: 'silent' },
 
-      globals: false,
+  //     globals: false,
 
-      hooks: {
-        // Inject the sockets hook in this repo into this Sails app
-        sockets: require('../')
-      },
+  //     hooks: {
+  //       // Inject the sockets hook in this repo into this Sails app
+  //       sockets: require('../')
+  //     },
 
-      loadHooks: ['moduleloader', 'userconfig', 'http', 'sockets'],
+  //     loadHooks: ['moduleloader', 'userconfig', 'http', 'sockets'],
 
-      // Configure the socket.io-redis adapter
-      sockets: {
-        adapter: 'socket.io-redis',
-        adapterModule: SocketIORedisAdapter,
+  //     // Configure the socket.io-redis adapter
+  //     sockets: {
+  //       adapter: 'socket.io-redis',
+  //       adapterModule: SocketIORedisAdapter,
 
-        // Configure port to match .travis.yml
-        port: 6380,
+  //       // Configure port to match .travis.yml
+  //       port: 6380,
 
-        // Should fail, because by default Redis only has 16 dbs
-        db: 99,
+  //       // Should fail, because by default Redis only has 16 dbs
+  //       db: 99,
 
-        // Configure password to match .travis.yml
-        pass: 'secret',
+  //       // Configure password to match .travis.yml
+  //       pass: 'secret',
 
-      }
-    }, function(err) {
+  //     }
+  //   }, function(err) {
 
-      if (err) {
-        assert.equal(err.code, 'E_INVALID_DB_INDEX', 'Got wrong kind of error: ' + util.inspect(err,  {depth: null}));
-        return done();
-      }
+  //     if (err) {
+  //       assert.equal(err.code, 'E_INVALID_DB_INDEX', 'Got wrong kind of error: ' + util.inspect(err,  {depth: null}));
+  //       return done();
+  //     }
 
-      return done(new Error('Should have failed to lift!'));
+  //     return done(new Error('Should have failed to lift!'));
 
-    });
+  //   });
 
-  });
+  // });
 
   it('Should fail to lift when incorrect password is supplied', function(done) {
 

--- a/test/with-redis.test.js
+++ b/test/with-redis.test.js
@@ -11,7 +11,7 @@ var SocketIORedisAdapter = require('socket.io-redis');
 var lifecycle = require('./helpers/lifecycle.helper');
 
 
-(require('os').platform() === 'win32' ? describe.skip : describe)('with redis', function (){
+describe('with redis', function (){
 
   before(lifecycle.setup);
   after(lifecycle.teardown);

--- a/test/with-redis.test.js
+++ b/test/with-redis.test.js
@@ -11,7 +11,7 @@ var SocketIORedisAdapter = require('socket.io-redis');
 var lifecycle = require('./helpers/lifecycle.helper');
 
 
-(require('os').platform() === 'win32' ? describe.skip : describe)('with redis', function (){
+describe('with redis', function (){
 
   before(lifecycle.setup);
   after(lifecycle.teardown);
@@ -146,7 +146,7 @@ var lifecycle = require('./helpers/lifecycle.helper');
     }, done);
   });
 
-  describe('all apps', function (){
+  (require('os').platform() === 'win32' ? describe.skip : describe)('all apps', function (){
 
     describe('after each app has at least one socket connected', function (){
 

--- a/test/with-redis.test.js
+++ b/test/with-redis.test.js
@@ -10,10 +10,6 @@ var Sails = require('sails').Sails;
 var SocketIORedisAdapter = require('socket.io-redis');
 var lifecycle = require('./helpers/lifecycle.helper');
 
-// TODO:
-// figure out how to make this run on Travis
-// (need a local redis)
-
 
 (require('os').platform() === 'win32' ? describe.skip : describe)('with redis', function (){
 

--- a/test/with-redis.test.js
+++ b/test/with-redis.test.js
@@ -15,7 +15,7 @@ var lifecycle = require('./helpers/lifecycle.helper');
 // (need a local redis)
 
 
-describe('with redis', function (){
+(require('os').platform() === 'win32' ? describe.skip : describe)('with redis', function (){
 
   before(lifecycle.setup);
   after(lifecycle.teardown);

--- a/test/with-redis.test.js
+++ b/test/with-redis.test.js
@@ -11,7 +11,7 @@ var SocketIORedisAdapter = require('socket.io-redis');
 var lifecycle = require('./helpers/lifecycle.helper');
 
 
-describe('with redis', function (){
+(require('os').platform() === 'win32' ? describe.skip : describe)('with redis', function (){
 
   before(lifecycle.setup);
   after(lifecycle.teardown);
@@ -146,7 +146,7 @@ describe('with redis', function (){
     }, done);
   });
 
-  (require('os').platform() === 'win32' ? describe.skip : describe)('all apps', function (){
+  describe('all apps', function (){
 
     describe('after each app has at least one socket connected', function (){
 

--- a/test/with-redis.test.js
+++ b/test/with-redis.test.js
@@ -11,7 +11,7 @@ var SocketIORedisAdapter = require('socket.io-redis');
 var lifecycle = require('./helpers/lifecycle.helper');
 
 
-describe('with redis', function (){
+(require('os').platform() === 'win32' ? describe.skip : describe)('with redis', function (){
 
   before(lifecycle.setup);
   after(lifecycle.teardown);


### PR DESCRIPTION
• Upgraded machinepack-redis and machinepack-urls to latest versions, and updated usage where it needed to change (e.g. changing `.execSync()` to `.now()`)
• Upgraded socket.io from 2.0.3 to 2.2.0 to resolve deprecation warning

I tested by linking my branch to a new sails app and testing out resourceful pubsub methods w/ blueprints