### PR TITLE
Give the name a hook, so can disable it in sailsrc

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "url": "git://github.com/balderdashy/sails-hook-sockets.git"
   },
   "sails": {
-    "isHook": true
+    "isHook": true,
+    "hookName": "sockets"
   },
   "author": "Mike McNeil",
   "license": "MIT"


### PR DESCRIPTION
With this change, cannow disable in .sailsrc with:

```
"hooks": {
  "sockets": false
}
```

It's not possible to disable it without this, is that correct?