### PR TITLE
Upgrading to socket.io v2.4.1 to fix vulnerability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@
 language: node_js
 
 node_js:
-  - "6"
-  - "8"
   - "10"
+  - "12"
+  - "14"
   - "node"
 
 branches:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,9 +13,9 @@
 # Test against these versions of Node.js.
 environment:
   matrix:
-    - nodejs_version: "6"
-    - nodejs_version: "8"
     - nodejs_version: "10"
+    - nodejs_version: "12"
+    - nodejs_version: "14"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,9 +13,9 @@
 # Test against these versions of Node.js.
 environment:
   matrix:
+    - nodejs_version: "6"
+    - nodejs_version: "8"
     - nodejs_version: "10"
-    - nodejs_version: "12"
-    - nodejs_version: "14"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "machinepack-urls": "^6.0.2-0",
     "proxy-addr": "1.1.5",
     "semver": "4.3.6",
-    "socket.io": "2.2.0",
+    "socket.io": "2.4.1",
     "uid2": "0.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@sailshq/lodash": "^3.10.2",
     "async": "2.0.1",
     "flaverr": "^1.0.0",
-    "machinepack-redis": "^2.0.3", 
+    "machinepack-redis": "^2.0.3",
     "machinepack-urls": "^6.0.2-0",
     "proxy-addr": "1.1.5",
     "semver": "4.3.6",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@sailshq/lodash": "^3.10.2",
     "async": "2.0.1",
     "flaverr": "^1.0.0",
-    "machinepack-redis": "^2.0.3",
+    "machinepack-redis": "^2.0.6",
     "machinepack-urls": "^6.0.2-0",
     "proxy-addr": "1.1.5",
     "semver": "4.3.6",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "machinepack-urls": "^6.0.2-0",
     "proxy-addr": "1.1.5",
     "semver": "4.3.6",
-    "socket.io": "2.4.1",
+    "socket.io": "2.2.0",
     "uid2": "0.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@sailshq/lodash": "^3.10.2",
     "async": "2.0.1",
     "flaverr": "^1.0.0",
-    "machinepack-redis": "^2.0.6",
+    "machinepack-redis": "^2.0.3",
     "machinepack-urls": "^6.0.2-0",
     "proxy-addr": "1.1.5",
     "semver": "4.3.6",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@sailshq/lodash": "^3.10.2",
     "async": "2.0.1",
     "flaverr": "^1.0.0",
-    "machinepack-redis": "^2.0.3",
+    "machinepack-redis": "^2.0.3", 
     "machinepack-urls": "^6.0.2-0",
     "proxy-addr": "1.1.5",
     "semver": "4.3.6",


### PR DESCRIPTION
- Upgrading `socket.io` from 2.2.0 -> 2.4.1 to resolve a vulnerability