### PR TITLE
Upgrade Socket.io dependency (`2.5.0` » `4.7.2`)

### DIFF
--- a/lib/initialize.js
+++ b/lib/initialize.js
@@ -64,8 +64,9 @@ module.exports = function ToInitialize(app) {
       // Now start socket.io
       var io = SocketIO(sailsHttpServer, (function _createOptsObj() {
         var opts = {
+          allowEIO3: true,
           path: app.config.sockets.path,
-          wsEngine: 'ws'
+          wsEngine: require('ws').Server,
         };
         if (typeof app.config.sockets.serveClient !== 'undefined') {
           opts.serveClient = app.config.sockets.serveClient;
@@ -138,7 +139,8 @@ module.exports = function ToInitialize(app) {
           opts.cookie = app.config.sockets.cookie;
         }
         if (app.config.sockets.onlyAllowOrigins) {
-          opts.origins = function(origin, cb) {
+          opts.cors = {};
+          opts.cors.origin = function(origin, cb) {
             // If the socket's origin is in the `onlyAllowOrigins` array, allow the connection to continue.
             if (_.contains(app.config.sockets.onlyAllowOrigins, origin)) {
               return cb(null, true);
@@ -179,7 +181,7 @@ module.exports = function ToInitialize(app) {
         });
 
         // Set up event listeners each time a new socket connects
-        io.on('connect', onConnect);
+        io.on('connection', onConnect);
 
 
         // Expose low-level, generic socket methods as `sails.sockets.*`

--- a/lib/initialize.js
+++ b/lib/initialize.js
@@ -139,7 +139,7 @@ module.exports = function ToInitialize(app) {
           opts.cookie = app.config.sockets.cookie;
         }
         if (app.config.sockets.onlyAllowOrigins) {
-          // As of Socket.io v3.X, the origins option was changed to origins, and is now nested in a dictornary named cors.
+          // As of Socket.io v3.X, the origins option was changed to origin, and is now nested in a dictionary named cors.
           opts.cors = {};// [?]: https://socket.io/docs/v4/migrating-from-2-x-to-3-0/#cors-handling
           opts.cors.origin = function(origin, cb) {
             // If the socket's origin is in the `onlyAllowOrigins` array, allow the connection to continue.

--- a/lib/initialize.js
+++ b/lib/initialize.js
@@ -64,9 +64,9 @@ module.exports = function ToInitialize(app) {
       // Now start socket.io
       var io = SocketIO(sailsHttpServer, (function _createOptsObj() {
         var opts = {
-          allowEIO3: true,
+          allowEIO3: true,// Allows support for Engine.io v3 clients.
           path: app.config.sockets.path,
-          wsEngine: require('ws').Server,
+          wsEngine: require('ws').Server,// [?]: https://socket.io/docs/v4/migrating-from-3-x-to-4-0/#wsengine-option
         };
         if (typeof app.config.sockets.serveClient !== 'undefined') {
           opts.serveClient = app.config.sockets.serveClient;
@@ -139,7 +139,8 @@ module.exports = function ToInitialize(app) {
           opts.cookie = app.config.sockets.cookie;
         }
         if (app.config.sockets.onlyAllowOrigins) {
-          opts.cors = {};
+          // As of Socket.io v3.X, the origins option was changed to origins, and is now nested in a dictornary named cors.
+          opts.cors = {};// [?]: https://socket.io/docs/v4/migrating-from-2-x-to-3-0/#cors-handling
           opts.cors.origin = function(origin, cb) {
             // If the socket's origin is in the `onlyAllowOrigins` array, allow the connection to continue.
             if (_.contains(app.config.sockets.onlyAllowOrigins, origin)) {
@@ -181,6 +182,7 @@ module.exports = function ToInitialize(app) {
         });
 
         // Set up event listeners each time a new socket connects
+        // Note: as of Socket.io 3.x, this event's name changed ('connect' » 'connection')
         io.on('connection', onConnect);
 
 

--- a/lib/prepare-adapter.js
+++ b/lib/prepare-adapter.js
@@ -114,9 +114,18 @@ module.exports = function (app){
 
         // Initialize the socket.io adapter (e.g. socket.io-redis or @sailshq/socket.io-redis)
         var sioAdapter = SocketIOAdapter(adapterConfig);
-
         // Attach the adapter to socket.io.
         app.io.adapter(sioAdapter);
+
+        // See https://github.com/socketio/socket.io-redis-adapter/issues/21#issuecomment-60334627
+        try {
+            app.io.of('/').adapter.on('error', (e)=>{
+              app.log.verbose('Socket.io adapter emitted error event:',e);
+            })
+        }
+        catch (e) {
+           app.log.error('Error building socket.io adapter:',e);
+        }
 
         // Set up a connection to the admin bus.
         var adminAdapterConfig = _.defaults(_.clone(app.config.sockets.adminAdapterOptions), _.omit(app.config.sockets.adapterOptions, 'pubClient', 'subClient'));

--- a/lib/prepare-adapter.js
+++ b/lib/prepare-adapter.js
@@ -119,9 +119,9 @@ module.exports = function (app){
 
         // See https://github.com/socketio/socket.io-redis-adapter/issues/21#issuecomment-60334627
         try {
-          app.io.of('/').adapter.on('error', (e)=>{
+          app.io.of('/').adapter.on('error', function(e){
             app.log.verbose('Socket.io adapter emitted error event:',e);
-          })
+          });
         }
         catch (e) {
           app.log.error('Error building socket.io adapter:',e);

--- a/lib/prepare-adapter.js
+++ b/lib/prepare-adapter.js
@@ -119,12 +119,12 @@ module.exports = function (app){
 
         // See https://github.com/socketio/socket.io-redis-adapter/issues/21#issuecomment-60334627
         try {
-            app.io.of('/').adapter.on('error', (e)=>{
-              app.log.verbose('Socket.io adapter emitted error event:',e);
-            })
+          app.io.of('/').adapter.on('error', (e)=>{
+            app.log.verbose('Socket.io adapter emitted error event:',e);
+          })
         }
         catch (e) {
-           app.log.error('Error building socket.io adapter:',e);
+          app.log.error('Error building socket.io adapter:',e);
         }
 
         // Set up a connection to the admin bus.

--- a/lib/prepare-adapter.js
+++ b/lib/prepare-adapter.js
@@ -15,7 +15,8 @@ module.exports = function (app){
   var prepareDriver = require('./prepare-driver')(app);
   var connectToAdminBus = require('./connect-to-admin-bus')(app);
 
-  var MINIMUM_SIO_REDIS_VERSION = '5.2.0';
+  // Latest socket.io-redis version that will create redis clients on behalf of the user.
+  var MINIMUM_SIO_REDIS_VERSION = '6.0.0';
 
   return function prepareAdapter(cb){
 
@@ -113,15 +114,6 @@ module.exports = function (app){
 
         // Initialize the socket.io adapter (e.g. socket.io-redis or @sailshq/socket.io-redis)
         var sioAdapter = SocketIOAdapter(adapterConfig);
-        // See https://github.com/Automattic/socket.io-redis/issues/21#issuecomment-60315678
-        try {
-          sioAdapter.prototype.on('error', function (e){
-            app.log.verbose('Socket.io adapter emitted error event:',e);
-          });
-        }
-        catch (e) {
-          app.log.error('Error building socket.io adapter:',e);
-        }
 
         // Attach the adapter to socket.io.
         app.io.adapter(sioAdapter);

--- a/lib/sails.sockets/add-room-members-to-rooms.js
+++ b/lib/sails.sockets/add-room-members-to-rooms.js
@@ -34,8 +34,9 @@ module.exports = function(app) {
 
     // If we were sent a socket ID as a room name, and the socket happens to
     // be connected to this server, take a shortcut
-    if (app.io.sockets.connected[sourceRoom]) {
-      return doJoin(app.io.sockets.connected[sourceRoom], cb);
+    if (app.io.of('/').sockets.has(sourceRoom)) {
+      doJoin(app.io.of('/').sockets.get(sourceRoom), cb);
+      return;
     }
 
     // Broadcast an admin message telling all other connected servers to
@@ -45,30 +46,34 @@ module.exports = function(app) {
       app.hooks.sockets.broadcastAdminMessage('join', {sourceRoom: sourceRoom, destRooms: destRooms});
     }
 
-
     // Look up all members of sourceRoom
-    return app.io.sockets.in(sourceRoom).clients(function(err, sourceRoomSocketIds) {
-      if (err) {return cb(err);}
+    app.io.of('/').allSockets().then((allSockets) => {
+      var sourceRoomSocketIds = allSockets || new Set();
       // Loop through the socket IDs from the room
-      async.each(sourceRoomSocketIds, function(socketId, nextSocketId) {
-        // Check if the socket is connected to this server (since .clients() may someday work cross-server)
-        if (app.io.sockets.connected[socketId]) {
+      async.each(Array.from(sourceRoomSocketIds), function(socketId, nextSocketId) {
+        // Check if the socket is connected to this server
+        if (app.io.of('/').sockets.has(socketId)) {
           // If so, subscribe it to destRooms
-          return doJoin(app.io.sockets.connected[socketId], nextSocketId);
+          doJoin(app.io.of('/').sockets.get(socketId), nextSocketId);
+        } else {
+          // If not, just continue
+          nextSocketId();
         }
-        // If not, just continue
-        return nextSocketId();
       }, cb);
+    }).catch((err) => {
+      cb(err);
     });
 
     function doJoin(socket, cb) {
-      return async.each(destRooms, function(destRoom, nextRoom) {
+      async.each(destRooms, function(destRoom, nextRoom) {
         // Ensure destRoom is a string
         if (!_.isString(destRoom)) {
           app.log.warn("Skipping non-string value for room name to add in `addRoomMembersToRooms`: ", destRoom);
-          return nextRoom();
+          nextRoom();
+        } else {
+          socket.join(destRoom);
+          nextRoom();
         }
-        return socket.join(destRoom, nextRoom);
       }, cb);
     }
 

--- a/lib/sails.sockets/add-room-members-to-rooms.js
+++ b/lib/sails.sockets/add-room-members-to-rooms.js
@@ -35,7 +35,8 @@ module.exports = function(app) {
     // If we were sent a socket ID as a room name, and the socket happens to
     // be connected to this server, take a shortcut
     if (app.io.of('/').sockets.has(sourceRoom)) {
-      return doJoin(app.io.of('/').sockets.get(sourceRoom), cb);
+      doJoin(app.io.of('/').sockets.get(sourceRoom));
+      return cb();
     }
 
     // Broadcast an admin message telling all other connected servers to
@@ -47,32 +48,30 @@ module.exports = function(app) {
 
 
     // Look up all members of sourceRoom
-    return (function(iifeDone) { app.io.in(sourceRoom).allSockets().then(function(sourceRoomSocketIds) {iifeDone(null, sourceRoomSocketIds);}).catch(function(err) { iifeDone(err, null)});})(function(err, sourceRoomSocketIds) {
+    return (function(iifeDone) { app.io.in(sourceRoom).allSockets().then(function(sourceRoomSocketIds) {iifeDone(undefined, sourceRoomSocketIds);}).catch(function(err) { iifeDone(err);});})(function(err, sourceRoomSocketIds) {
       if (err) { return cb(err); }
       // Loop through the socket IDs from the room
       sourceRoomSocketIds.forEach(function(socketId) {
         // Check if the socket is connected to this server
         if (app.io.of('/').sockets.has(socketId)) {
           // If so, subscribe it to destRooms
-          return doJoin(app.io.of('/').sockets.get(socketId));
+          doJoin(app.io.of('/').sockets.get(socketId));
         }
         // If not, just continue
-        return;
       });
-    });
+      cb();
+    });//_∏_
 
 
-    function doJoin(socket, cb) {
+    function doJoin(socket) {
       destRooms.forEach(function(destRoom) {
         // Ensure destRoom is a string
         if (!_.isString(destRoom)) {
           app.log.warn("Skipping non-string value for room name to add in `addRoomMembersToRooms`: ", destRoom);
-          return;
         } else {
-          return socket.join(destRoom);
+          socket.join(destRoom);
         }
       });
-      cb();
     }
 
   };

--- a/lib/sails.sockets/add-room-members-to-rooms.js
+++ b/lib/sails.sockets/add-room-members-to-rooms.js
@@ -35,8 +35,7 @@ module.exports = function(app) {
     // If we were sent a socket ID as a room name, and the socket happens to
     // be connected to this server, take a shortcut
     if (app.io.of('/').sockets.has(sourceRoom)) {
-      doJoin(app.io.of('/').sockets.get(sourceRoom), cb);
-      return;
+      return doJoin(app.io.of('/').sockets.get(sourceRoom), cb);
     }
 
     // Broadcast an admin message telling all other connected servers to
@@ -46,28 +45,22 @@ module.exports = function(app) {
       app.hooks.sockets.broadcastAdminMessage('join', {sourceRoom: sourceRoom, destRooms: destRooms});
     }
 
+
     // Look up all members of sourceRoom
-    return (function(iifeDone) {
-      app.io.in(sourceRoom).allSockets().then(function(sourceRoomSocketIds) {
-        // Loop through the socket IDs from the room
-        sourceRoomSocketIds.forEach(function(socketId) {
-          // Check if the socket is connected to this server
-          if (app.io.of('/').sockets.has(socketId)) {
-            // If so, subscribe it to destRooms
-            return doJoin(app.io.of('/').sockets.get(socketId));
-          }
-          // If not, just continue
-          return;
-        });
-        iifeDone();
-      })
-      .catch(function(err) {
-        iifeDone(err);
-      });
-    })(function(err) {
+    return (function(iifeDone) { app.io.in(sourceRoom).allSockets().then(function(sourceRoomSocketIds) {iifeDone(null, sourceRoomSocketIds);}).catch(function(err) { iifeDone(err, null)});})(function(err, sourceRoomSocketIds) {
       if (err) { return cb(err); }
-      cb();
+      // Loop through the socket IDs from the room
+      sourceRoomSocketIds.forEach(function(socketId) {
+        // Check if the socket is connected to this server
+        if (app.io.of('/').sockets.has(socketId)) {
+          // If so, subscribe it to destRooms
+          return doJoin(app.io.of('/').sockets.get(socketId));
+        }
+        // If not, just continue
+        return;
+      });
     });
+
 
     function doJoin(socket, cb) {
       destRooms.forEach(function(destRoom) {

--- a/lib/sails.sockets/add-room-members-to-rooms.js
+++ b/lib/sails.sockets/add-room-members-to-rooms.js
@@ -47,21 +47,27 @@ module.exports = function(app) {
     }
 
     // Look up all members of sourceRoom
-    app.io.of('/').allSockets().then((allSockets) => {
-      var sourceRoomSocketIds = allSockets || new Set();
-      // Loop through the socket IDs from the room
-      async.each(Array.from(sourceRoomSocketIds), function(socketId, nextSocketId) {
-        // Check if the socket is connected to this server
-        if (app.io.of('/').sockets.has(socketId)) {
-          // If so, subscribe it to destRooms
-          doJoin(app.io.of('/').sockets.get(socketId), nextSocketId);
-        } else {
-          // If not, just continue
-          nextSocketId();
-        }
-      }, cb);
-    }).catch((err) => {
-      cb(err);
+    return (function(iifeDone) {
+      app.io.in(sourceRoom).allSockets().then(function(sourceRoomSocketIds) {
+          // Convert the Set returned from the AllSockets() method to an array.
+          sourceRoomSocketIds = Array.from(sourceRoomSocketIds);
+          async.each(sourceRoomSocketIds, function(socketId, nextSocketId) {
+            // Check if the socket is connected to this server
+            if (app.io.of('/').sockets.has(socketId)) {
+              // If so, unsubscribe it from destRooms
+              return doJoin(app.io.of('/').sockets.get(socketId), nextSocketId);
+            }
+            // If not, just continue
+            return nextSocketId();
+          }, iifeDone);
+        })
+        .catch(function(err) {
+          iifeDone(err);
+        });
+    })(function(err) {
+      // This is the original callback
+      if (err) { return cb(err); }
+      cb();
     });
 
     function doJoin(socket, cb) {

--- a/lib/sails.sockets/add-room-members-to-rooms.js
+++ b/lib/sails.sockets/add-room-members-to-rooms.js
@@ -49,38 +49,37 @@ module.exports = function(app) {
     // Look up all members of sourceRoom
     return (function(iifeDone) {
       app.io.in(sourceRoom).allSockets().then(function(sourceRoomSocketIds) {
-          // Convert the Set returned from the AllSockets() method to an array.
-          sourceRoomSocketIds = Array.from(sourceRoomSocketIds);
-          async.each(sourceRoomSocketIds, function(socketId, nextSocketId) {
-            // Check if the socket is connected to this server
-            if (app.io.of('/').sockets.has(socketId)) {
-              // If so, unsubscribe it from destRooms
-              return doJoin(app.io.of('/').sockets.get(socketId), nextSocketId);
-            }
-            // If not, just continue
-            return nextSocketId();
-          }, iifeDone);
-        })
-        .catch(function(err) {
-          iifeDone(err);
+        // Loop through the socket IDs from the room
+        sourceRoomSocketIds.forEach(function(socketId) {
+          // Check if the socket is connected to this server
+          if (app.io.of('/').sockets.has(socketId)) {
+            // If so, subscribe it to destRooms
+            return doJoin(app.io.of('/').sockets.get(socketId));
+          }
+          // If not, just continue
+          return;
         });
+        iifeDone();
+      })
+      .catch(function(err) {
+        iifeDone(err);
+      });
     })(function(err) {
-      // This is the original callback
       if (err) { return cb(err); }
       cb();
     });
 
     function doJoin(socket, cb) {
-      async.each(destRooms, function(destRoom, nextRoom) {
+      destRooms.forEach(function(destRoom) {
         // Ensure destRoom is a string
         if (!_.isString(destRoom)) {
           app.log.warn("Skipping non-string value for room name to add in `addRoomMembersToRooms`: ", destRoom);
-          nextRoom();
+          return;
         } else {
-          socket.join(destRoom);
-          nextRoom();
+          return socket.join(destRoom);
         }
-      }, cb);
+      });
+      cb();
     }
 
   };

--- a/lib/sails.sockets/broadcast-to-room.js
+++ b/lib/sails.sockets/broadcast-to-room.js
@@ -60,13 +60,10 @@ module.exports = function (app){
       roomNames = [roomNames];
     }
 
-    // Tell the emitter each room to emit to
+    // Send the broadcast to the specified rooms.
     _.each(roomNames, function(roomName) {
-      emitter.in(roomName);
+      emitter.to(roomName).emit(eventName, data);
     });
-
-    // Send the broadcast
-    emitter.emit(eventName, data);
 
   };
 

--- a/lib/sails.sockets/get-socket-by-id.js
+++ b/lib/sails.sockets/get-socket-by-id.js
@@ -28,7 +28,7 @@ module.exports = function (app){
     }
 
     // Look for a socket with the specified ID in the default namespace
-    var foundSocket = app.io.sockets.connected[id];
+    var foundSocket = app.io.of('/').sockets.get(id);
     if (!foundSocket) {
       throw ERRORPACK.NO_SUCH_SOCKET('Cannot find socket with id=`%s`', id);
     }

--- a/lib/sails.sockets/join-room.js
+++ b/lib/sails.sockets/join-room.js
@@ -50,7 +50,9 @@ module.exports = function(app) {
 
     // Call the callback once all sockets have joined
     cb();
-
+    // The value returned from this function is currently used by the Sails PubSub hook.
+    // FUTURE: When https://github.com/balderdashy/sails/pull/7311/files is merged, this return value can be removed.
+    return true;
   };
 
 };

--- a/lib/sails.sockets/join-room.js
+++ b/lib/sails.sockets/join-room.js
@@ -26,16 +26,16 @@ module.exports = function(app) {
       sockets = [sockets];
     }
 
-    async.each(sockets, function(socket, nextSocket) {
+    sockets.forEach((socket)=> {
       // If a string was sent, try to look up a socket with that ID
       if (typeof socket !== 'object' && socket !== null) {
         // If we don't find one, it could be on another server, so use
         // the cross-server "addRoomMembersToRooms"
-        if (!app.io.sockets.connected[socket]) {
-          return app.sockets.addRoomMembersToRooms(socket, roomName, nextSocket);
+        if (!app.io.of('/').sockets.has(socket)) {
+          return app.sockets.addRoomMembersToRooms(socket, roomName);
         }
         // Otherwise get the socket object and continue
-        socket = app.io.sockets.connected[socket];
+        socket = app.io.of('/').sockets.get(socket);
       }
 
       // If it's not a valid socket object, bail
@@ -45,10 +45,11 @@ module.exports = function(app) {
         return;
       }
       // Join up!
-      socket.join(roomName, nextSocket);
+      socket.join(roomName);
+    });
 
-    }, cb);
-
+    // Call the callback once all sockets have joined
+    cb();
     return true;
 
   };

--- a/lib/sails.sockets/join-room.js
+++ b/lib/sails.sockets/join-room.js
@@ -50,7 +50,6 @@ module.exports = function(app) {
 
     // Call the callback once all sockets have joined
     cb();
-    return true;
 
   };
 

--- a/lib/sails.sockets/leave-all-rooms.js
+++ b/lib/sails.sockets/leave-all-rooms.js
@@ -44,28 +44,28 @@ module.exports = function(app) {
     }
 
     // Look up all members of sourceRoom
-    return app.io.sockets.in(sourceRoom).clients(function(err, sourceRoomSocketIds) {
-      if (err) {return cb(err);}
-      // Loop through the socket IDs from the room
-      async.each(sourceRoomSocketIds, function(socketId, nextSocketId) {
-        // Check if the socket is connected to this server (since .clients() may someday work cross-server)
-        if (app.io.sockets.connected[socketId]) {
-          // If so, unsubscribe it from all rooms it is currently subscribed to
-          var socket = app.io.sockets.connected[socketId];
-          var destRooms = _.keys(socket.rooms);
-          return async.each(destRooms, function(destRoom, nextRoom) {
-            // Don't unsubscribe a socket from its own room unless we're explicitly asked to
-            if (options.includeSocketRooms !== true && destRoom == socketId) {return nextRoom();}
-            // Don't unsubscribe a socket from its the source room unless we're explicitly asked to
-            if (options.includeSourceRoom !== true && destRoom == sourceRoom) {return nextRoom();}
-            return socket.leave(destRoom, nextRoom);
-          }, nextSocketId);
-        }
-        // If not, just continue
-        return nextSocketId();
-      }, cb);
-    });
+    app.io.of('/').in(sourceRoom).allSockets()
+      .then((sourceRoomSocketIds) => {
+        sourceRoomSocketIds.forEach((socketId) => {
+          let socket = app.io.of('/').sockets.get(socketId);
+          if (socket) {
+            let destRooms = Array.from(socket.rooms);
+            destRooms.forEach((destRoom) => {
+              if ((options.includeSocketRooms !== true && destRoom === socketId) ||
+                  (options.includeSourceRoom !== true && destRoom === sourceRoom)) {
+                return;
+              }
+              socket.leave(destRoom);
+            });
+          }
+        });
+        cb();
+      })
+      .catch((err) => {
+        cb(err);
+      });
 
+    return true;
   };
 
 };

--- a/lib/sails.sockets/leave-all-rooms.js
+++ b/lib/sails.sockets/leave-all-rooms.js
@@ -44,26 +44,31 @@ module.exports = function(app) {
     }
 
     // Look up all members of sourceRoom
-    app.io.of('/').in(sourceRoom).allSockets()
-      .then((sourceRoomSocketIds) => {
-        sourceRoomSocketIds.forEach((socketId) => {
-          let socket = app.io.of('/').sockets.get(socketId);
-          if (socket) {
-            let destRooms = Array.from(socket.rooms);
-            destRooms.forEach((destRoom) => {
-              if ((options.includeSocketRooms !== true && destRoom === socketId) ||
-                  (options.includeSourceRoom !== true && destRoom === sourceRoom)) {
-                return;
-              }
-              socket.leave(destRoom);
-            });
-          }
-        });
-        cb();
-      })
-      .catch((err) => {
-        cb(err);
+    app.io.of('/').in(sourceRoom).allSockets().then(function (sourceRoomSocketIds) {
+      var arrayOfSorceRoomSocketIds = Array.from(sourceRoomSocketIds);
+      // Loop through the socket IDs from the room
+      arrayOfSorceRoomSocketIds.forEach((socketId) => {
+        // Check if the socket is connected to this server
+        if (app.io.of('/').sockets.has(socketId)) {
+          // If so, unsubscribe it from all rooms it is currently subscribed to
+          var socket = app.io.of('/').sockets.get(socketId);
+          // Create an array from the set of socket rooms.
+          var destRooms = Array.from(socket.rooms);
+          destRooms.forEach((destRoom) => {
+            // Don't unsubscribe a socket from its own room unless we're explicitly asked to
+            if (options.includeSocketRooms !== true && destRoom == socketId) {return;}
+            // Don't unsubscribe a socket from its the source room unless we're explicitly asked to
+            if (options.includeSourceRoom !== true && destRoom == sourceRoom) {return;}
+            return socket.leave(destRoom);
+          });// For each destRoom.
+        }
       });
+      cb();
+    })
+    .catch((err) => {
+      cb(err);
+    });
+
 
     return true;
   };

--- a/lib/sails.sockets/leave-all-rooms.js
+++ b/lib/sails.sockets/leave-all-rooms.js
@@ -43,33 +43,26 @@ module.exports = function(app) {
       app.hooks.sockets.broadcastAdminMessage('leaveAll', {sourceRoom: sourceRoom});
     }
 
-    return (function(iifeDone) {
-      // Look up all members of sourceRoom
-      app.io.of('/').in(sourceRoom).allSockets().then(function(sourceRoomSocketIds) {
-          // Loop through the socket IDs from the room
-          sourceRoomSocketIds.forEach((socketId) => {
-            // Check if the socket is connected to this server
-            if (app.io.of('/').sockets.has(socketId)) {
-              // If so, unsubscribe it from all rooms it is currently subscribed to
-              var socket = app.io.of('/').sockets.get(socketId);
-              // Create an array from the set of socket rooms.
-              var destRooms = Array.from(socket.rooms);
-              destRooms.forEach((destRoom) => {
-                // Don't unsubscribe a socket from its own room unless we're explicitly asked to
-                if (options.includeSocketRooms !== true && destRoom == socketId) {return;}
-                // Don't unsubscribe a socket from its the source room unless we're explicitly asked to
-                if (options.includeSourceRoom !== true && destRoom == sourceRoom) {return;}
-                socket.leave(destRoom);
-              }); // For each destRoom.
-            }
-          });
-          iifeDone();
-        })
-        .catch((err) => {
-          iifeDone(err);
-        });
-    })(function(err) {
+    // Look up all members of sourceRoom
+    return (function(iifeDone) { app.io.in(sourceRoom).allSockets().then(function(sourceRoomSocketIds) {iifeDone(null, sourceRoomSocketIds);}).catch(function(err) { iifeDone(err, null)});})(function(err, sourceRoomSocketIds) {
       if (err) { return cb(err); }
+      // Loop through the socket IDs from the room
+      sourceRoomSocketIds.forEach((socketId) => {
+        // Check if the socket is connected to this server
+        if (app.io.of('/').sockets.has(socketId)) {
+          // If so, unsubscribe it from all rooms it is currently subscribed to
+          var socket = app.io.of('/').sockets.get(socketId);
+          // Create an array from the set of socket rooms.
+          var destRooms = Array.from(socket.rooms);
+          destRooms.forEach((destRoom) => {
+            // Don't unsubscribe a socket from its own room unless we're explicitly asked to
+            if (options.includeSocketRooms !== true && destRoom == socketId) {return;}
+            // Don't unsubscribe a socket from its the source room unless we're explicitly asked to
+            if (options.includeSourceRoom !== true && destRoom == sourceRoom) {return;}
+            socket.leave(destRoom);
+          }); // For each destRoom.
+        }
+      });
       cb();
     });
 

--- a/lib/sails.sockets/leave-all-rooms.js
+++ b/lib/sails.sockets/leave-all-rooms.js
@@ -43,34 +43,36 @@ module.exports = function(app) {
       app.hooks.sockets.broadcastAdminMessage('leaveAll', {sourceRoom: sourceRoom});
     }
 
-    // Look up all members of sourceRoom
-    app.io.of('/').in(sourceRoom).allSockets().then(function (sourceRoomSocketIds) {
-      var arrayOfSorceRoomSocketIds = Array.from(sourceRoomSocketIds);
-      // Loop through the socket IDs from the room
-      arrayOfSorceRoomSocketIds.forEach((socketId) => {
-        // Check if the socket is connected to this server
-        if (app.io.of('/').sockets.has(socketId)) {
-          // If so, unsubscribe it from all rooms it is currently subscribed to
-          var socket = app.io.of('/').sockets.get(socketId);
-          // Create an array from the set of socket rooms.
-          var destRooms = Array.from(socket.rooms);
-          destRooms.forEach((destRoom) => {
-            // Don't unsubscribe a socket from its own room unless we're explicitly asked to
-            if (options.includeSocketRooms !== true && destRoom == socketId) {return;}
-            // Don't unsubscribe a socket from its the source room unless we're explicitly asked to
-            if (options.includeSourceRoom !== true && destRoom == sourceRoom) {return;}
-            return socket.leave(destRoom);
-          });// For each destRoom.
-        }
-      });
+    return (function(iifeDone) {
+      // Look up all members of sourceRoom
+      app.io.of('/').in(sourceRoom).allSockets().then(function(sourceRoomSocketIds) {
+          // Loop through the socket IDs from the room
+          sourceRoomSocketIds.forEach((socketId) => {
+            // Check if the socket is connected to this server
+            if (app.io.of('/').sockets.has(socketId)) {
+              // If so, unsubscribe it from all rooms it is currently subscribed to
+              var socket = app.io.of('/').sockets.get(socketId);
+              // Create an array from the set of socket rooms.
+              var destRooms = Array.from(socket.rooms);
+              destRooms.forEach((destRoom) => {
+                // Don't unsubscribe a socket from its own room unless we're explicitly asked to
+                if (options.includeSocketRooms !== true && destRoom == socketId) {return;}
+                // Don't unsubscribe a socket from its the source room unless we're explicitly asked to
+                if (options.includeSourceRoom !== true && destRoom == sourceRoom) {return;}
+                socket.leave(destRoom);
+              }); // For each destRoom.
+            }
+          });
+          iifeDone();
+        })
+        .catch((err) => {
+          iifeDone(err);
+        });
+    })(function(err) {
+      if (err) { return cb(err); }
       cb();
-    })
-    .catch((err) => {
-      cb(err);
     });
 
-
-    return true;
   };
 
 };

--- a/lib/sails.sockets/leave-all-rooms.js
+++ b/lib/sails.sockets/leave-all-rooms.js
@@ -44,7 +44,7 @@ module.exports = function(app) {
     }
 
     // Look up all members of sourceRoom
-    return (function(iifeDone) { app.io.in(sourceRoom).allSockets().then(function(sourceRoomSocketIds) {iifeDone(null, sourceRoomSocketIds);}).catch(function(err) { iifeDone(err, null)});})(function(err, sourceRoomSocketIds) {
+    return (function(iifeDone) { app.io.in(sourceRoom).allSockets().then(function(sourceRoomSocketIds) {iifeDone(undefined, sourceRoomSocketIds);}).catch(function(err) { iifeDone(err);});})(function(err, sourceRoomSocketIds) {
       if (err) { return cb(err); }
       // Loop through the socket IDs from the room
       sourceRoomSocketIds.forEach((socketId) => {

--- a/lib/sails.sockets/leave-room.js
+++ b/lib/sails.sockets/leave-room.js
@@ -49,6 +49,8 @@ module.exports = function(app) {
 
     // Call the callback once all sockets have left
     cb();
+    // The value returned from this function is currently used by the Sails PubSub hook.
+    // FUTURE: When https://github.com/balderdashy/sails/pull/7311/files is merged, this return value can be removed.
     return true;
   };
 };

--- a/lib/sails.sockets/leave-room.js
+++ b/lib/sails.sockets/leave-room.js
@@ -25,16 +25,16 @@ module.exports = function(app) {
       sockets = [sockets];
     }
 
-    async.each(sockets, function(socket, nextSocket) {
+    sockets.forEach((socket)=> {
       // If a string was sent, try to look up a socket with that ID
       if (typeof socket !== 'object' && socket !== null) {
         // If we don't find one, it could be on another server, so use
         // the cross-server "removeRoomMembersFromRooms"
-        if (!app.io.sockets.connected[socket]) {
-          return app.sockets.removeRoomMembersFromRooms(socket, roomName, nextSocket);
+        if (!app.io.of('/').sockets.has(socket)) {
+          return app.sockets.removeRoomMembersFromRooms(socket, roomName);
         }
         // Otherwise get the socket object and continue
-        socket = app.io.sockets.connected[socket];
+        socket = app.io.of('/').sockets.get(socket);
       }
 
       // If it's not a valid socket object, bail
@@ -44,9 +44,11 @@ module.exports = function(app) {
         return;
       }
       // See ya!
-      socket.leave(roomName, nextSocket);
-    }, cb);
+      socket.leave(roomName);
+    });
 
+    // Call the callback once all sockets have left
+    cb();
     return true;
   };
 };

--- a/lib/sails.sockets/remove-room-members-from-rooms.js
+++ b/lib/sails.sockets/remove-room-members-from-rooms.js
@@ -48,41 +48,39 @@ module.exports = function(app) {
 
     // Look up all members of sourceRoom
     return (function(iifeDone) {
-      app.io.in(sourceRoom).allSockets()
-        .then(function(sourceRoomSocketIds) {
-          // Convert the Set returned from the AllSockets() method to an array.
-          sourceRoomSocketIds = Array.from(sourceRoomSocketIds);
-          async.each(sourceRoomSocketIds, function(socketId, nextSocketId) {
-            // Check if the socket is connected to this server
-            if (app.io.of('/').sockets.has(socketId)) {
-              // If so, unsubscribe it from destRooms
-              return doLeave(app.io.of('/').sockets.get(socketId), nextSocketId);
-            }
-            // If not, just continue
-            return nextSocketId();
-          }, iifeDone);
-        })
-        .catch(function(err) {
-          iifeDone(err);
-        });
+      app.io.in(sourceRoom).allSockets().then(function(sourceRoomSocketIds) {
+        // Loop through the socket IDs from the room
+      sourceRoomSocketIds.forEach(function(socketId) {
+        // Check if the socket is connected to this server
+        if (app.io.of('/').sockets.has(socketId)) {
+          // If so, unsubscribe it from destRooms
+          return doLeave(app.io.of('/').sockets.get(socketId));
+        }
+        // If not, just continue
+        return;
+      });
+        iifeDone();
+      })
+      .catch(function(err) {
+        iifeDone(err);
+      });
     })(function(err) {
-      // This is the original callback
       if (err) { return cb(err); }
       cb();
     });
 
 
     function doLeave(socket, cb) {
-      async.each(destRooms, function(destRoom, nextRoom) {
+      destRooms.forEach(function(destRoom) {
         // Ensure destRoom is a string
         if (!_.isString(destRoom)) {
           app.log.warn("Skipping non-string value for room name to add in `addRoomMembersToRooms`: ", destRoom);
-          nextRoom();
+          return;
         } else {
-          socket.leave(destRoom);
-          nextRoom();
+          return socket.leave(destRoom);
         }
-      }, cb);
+      });
+      cb();
     }
 
   };

--- a/lib/sails.sockets/remove-room-members-from-rooms.js
+++ b/lib/sails.sockets/remove-room-members-from-rooms.js
@@ -35,7 +35,8 @@ module.exports = function(app) {
     // If we were sent a socket ID as a room name, and the socket happens to
     // be connected to this server, take a shortcut
     if (app.io.of('/').sockets.has(sourceRoom)) {
-      return doLeave(app.io.of('/').sockets.get(sourceRoom), cb);
+      doLeave(app.io.of('/').sockets.get(sourceRoom));
+      return cb();
     }
 
     // Broadcast an admin message telling all other connected servers to
@@ -46,32 +47,30 @@ module.exports = function(app) {
     }
 
     // Look up all members of sourceRoom
-    return (function(iifeDone) { app.io.in(sourceRoom).allSockets().then(function(sourceRoomSocketIds) {iifeDone(null, sourceRoomSocketIds);}).catch(function(err) { iifeDone(err, null)});})(function(err, sourceRoomSocketIds) {
+    return (function(iifeDone) { app.io.in(sourceRoom).allSockets().then(function(sourceRoomSocketIds) {iifeDone(undefined, sourceRoomSocketIds);}).catch(function(err) { iifeDone(err);});})(function(err, sourceRoomSocketIds) {
       if (err) { return cb(err); }
       // Loop through the socket IDs from the room
       sourceRoomSocketIds.forEach(function(socketId) {
         // Check if the socket is connected to this server
         if (app.io.of('/').sockets.has(socketId)) {
           // If so, unsubscribe it from destRooms
-          return doLeave(app.io.of('/').sockets.get(socketId));
+          doLeave(app.io.of('/').sockets.get(socketId));
         }
         // If not, just continue
-        return;
       });
-    });
+      cb();
+    });//_∏_
 
 
-    function doLeave(socket, cb) {
+    function doLeave(socket) {
       destRooms.forEach(function(destRoom) {
         // Ensure destRoom is a string
         if (!_.isString(destRoom)) {
           app.log.warn("Skipping non-string value for room name to add in `addRoomMembersToRooms`: ", destRoom);
-          return;
         } else {
-          return socket.leave(destRoom);
+          socket.leave(destRoom);
         }
       });
-      cb();
     }
 
   };

--- a/lib/sails.sockets/remove-room-members-from-rooms.js
+++ b/lib/sails.sockets/remove-room-members-from-rooms.js
@@ -34,8 +34,9 @@ module.exports = function(app) {
 
     // If we were sent a socket ID as a room name, and the socket happens to
     // be connected to this server, take a shortcut
-    if (app.io.sockets.connected[sourceRoom]) {
-      return doLeave(app.io.sockets.connected[sourceRoom], cb);
+    if (app.io.of('/').sockets.has(sourceRoom)) {
+      doLeave(app.io.of('/').sockets.get(sourceRoom), cb);
+      return;
     }
 
     // Broadcast an admin message telling all other connected servers to
@@ -46,28 +47,33 @@ module.exports = function(app) {
     }
 
     // Look up all members of sourceRoom
-    return app.io.sockets.in(sourceRoom).clients(function(err, sourceRoomSocketIds) {
-      if (err) {return cb(err);}
+    app.io.of('/').allSockets().then((allSockets) => {
+      const sourceRoomSocketIds = allSockets || new Set();
       // Loop through the socket IDs from the room
-      async.each(sourceRoomSocketIds, function(socketId, nextSocketId) {
-        // Check if the socket is connected to this server (since .clients() may someday work cross-server)
-        if (app.io.sockets.connected[socketId]) {
-          // If so, unsubscribe it from destRooms
-          return doLeave(app.io.sockets.connected[socketId], nextSocketId);
+      async.each(Array.from(sourceRoomSocketIds), function(socketId, nextSocketId) {
+        // Check if the socket is connected to this server
+        if (app.io.of('/').sockets.has(socketId)) {
+          // If so, subscribe it to destRooms
+          doLeave(app.io.of('/').sockets.get(socketId), nextSocketId);
+        } else {
+          // If not, just continue
+          nextSocketId();
         }
-        // If not, just continue
-        return nextSocketId();
       }, cb);
+    }).catch((err) => {
+      cb(err);
     });
 
     function doLeave(socket, cb) {
-      return async.each(destRooms, function(destRoom, nextRoom) {
+      async.each(destRooms, function(destRoom, nextRoom) {
         // Ensure destRoom is a string
         if (!_.isString(destRoom)) {
-          app.log.warn("Skipping non-string value for room name to add in `removeRoomMembersFromRooms`: ", destRoom);
-          return nextRoom();
+          app.log.warn("Skipping non-string value for room name to add in `addRoomMembersToRooms`: ", destRoom);
+          nextRoom();
+        } else {
+          socket.leave(destRoom);
+          nextRoom();
         }
-        return socket.leave(destRoom, nextRoom);
       }, cb);
     }
 

--- a/lib/sails.sockets/remove-room-members-from-rooms.js
+++ b/lib/sails.sockets/remove-room-members-from-rooms.js
@@ -35,8 +35,7 @@ module.exports = function(app) {
     // If we were sent a socket ID as a room name, and the socket happens to
     // be connected to this server, take a shortcut
     if (app.io.of('/').sockets.has(sourceRoom)) {
-      doLeave(app.io.of('/').sockets.get(sourceRoom), cb);
-      return;
+      return doLeave(app.io.of('/').sockets.get(sourceRoom), cb);
     }
 
     // Broadcast an admin message telling all other connected servers to
@@ -47,9 +46,9 @@ module.exports = function(app) {
     }
 
     // Look up all members of sourceRoom
-    return (function(iifeDone) {
-      app.io.in(sourceRoom).allSockets().then(function(sourceRoomSocketIds) {
-        // Loop through the socket IDs from the room
+    return (function(iifeDone) { app.io.in(sourceRoom).allSockets().then(function(sourceRoomSocketIds) {iifeDone(null, sourceRoomSocketIds);}).catch(function(err) { iifeDone(err, null)});})(function(err, sourceRoomSocketIds) {
+      if (err) { return cb(err); }
+      // Loop through the socket IDs from the room
       sourceRoomSocketIds.forEach(function(socketId) {
         // Check if the socket is connected to this server
         if (app.io.of('/').sockets.has(socketId)) {
@@ -59,14 +58,6 @@ module.exports = function(app) {
         // If not, just continue
         return;
       });
-        iifeDone();
-      })
-      .catch(function(err) {
-        iifeDone(err);
-      });
-    })(function(err) {
-      if (err) { return cb(err); }
-      cb();
     });
 
 

--- a/lib/sails.sockets/remove-room-members-from-rooms.js
+++ b/lib/sails.sockets/remove-room-members-from-rooms.js
@@ -47,22 +47,30 @@ module.exports = function(app) {
     }
 
     // Look up all members of sourceRoom
-    app.io.of('/').allSockets().then((allSockets) => {
-      var sourceRoomSocketIds = allSockets || new Set();
-      // Loop through the socket IDs from the room
-      async.each(Array.from(sourceRoomSocketIds), function(socketId, nextSocketId) {
-        // Check if the socket is connected to this server
-        if (app.io.of('/').sockets.has(socketId)) {
-          // If so, subscribe it to destRooms
-          doLeave(app.io.of('/').sockets.get(socketId), nextSocketId);
-        } else {
-          // If not, just continue
-          nextSocketId();
-        }
-      }, cb);
-    }).catch((err) => {
-      cb(err);
+    return (function(iifeDone) {
+      app.io.in(sourceRoom).allSockets()
+        .then(function(sourceRoomSocketIds) {
+          // Convert the Set returned from the AllSockets() method to an array.
+          sourceRoomSocketIds = Array.from(sourceRoomSocketIds);
+          async.each(sourceRoomSocketIds, function(socketId, nextSocketId) {
+            // Check if the socket is connected to this server
+            if (app.io.of('/').sockets.has(socketId)) {
+              // If so, unsubscribe it from destRooms
+              return doLeave(app.io.of('/').sockets.get(socketId), nextSocketId);
+            }
+            // If not, just continue
+            return nextSocketId();
+          }, iifeDone);
+        })
+        .catch(function(err) {
+          iifeDone(err);
+        });
+    })(function(err) {
+      // This is the original callback
+      if (err) { return cb(err); }
+      cb();
     });
+
 
     function doLeave(socket, cb) {
       async.each(destRooms, function(destRoom, nextRoom) {

--- a/lib/sails.sockets/remove-room-members-from-rooms.js
+++ b/lib/sails.sockets/remove-room-members-from-rooms.js
@@ -48,7 +48,7 @@ module.exports = function(app) {
 
     // Look up all members of sourceRoom
     app.io.of('/').allSockets().then((allSockets) => {
-      const sourceRoomSocketIds = allSockets || new Set();
+      var sourceRoomSocketIds = allSockets || new Set();
       // Loop through the socket IDs from the room
       async.each(Array.from(sourceRoomSocketIds), function(socketId, nextSocketId) {
         // Check if the socket is connected to this server

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "sails": "^1.0.0-12",
     "sails.io.js": "^1.0.0",
     "socket.io-client": "2.0.3",
-    "socket.io-redis": "6.0.0"
+    "socket.io-redis": "6.1.0"
   },
   "scripts": {
     "test": "node ./node_modules/mocha/bin/mocha test --timeout 5000"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "ioredis": "2.4.0",
     "machinepack-fs": "^3.0.0",
-    "machinepack-http": "^9.0.0",
+    "machinepack-http": "^8.0.0",
     "mocha": "3.1.0",
     "redis": "2.6.3",
     "sails": "^1.0.0-12",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "machinepack-urls": "^6.0.2-0",
     "proxy-addr": "1.1.5",
     "semver": "7.5.2",
-    "socket.io": "2.5.0",
+    "socket.io": "4.7.2",
     "uid2": "0.0.3"
   },
   "devDependencies": {
@@ -28,7 +28,7 @@
     "sails": "^1.0.0-12",
     "sails.io.js": "^1.0.0",
     "socket.io-client": "2.0.3",
-    "socket.io-redis": "5.2.0"
+    "socket.io-redis": "6.0.0"
   },
   "scripts": {
     "test": "node ./node_modules/mocha/bin/mocha test --timeout 5000"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "ioredis": "2.4.0",
     "machinepack-fs": "^3.0.0",
-    "machinepack-http": "^8.0.0",
+    "machinepack-http": "^9.0.0",
     "mocha": "3.1.0",
     "redis": "2.6.3",
     "sails": "^1.0.0-12",

--- a/test/req.ip.test.js
+++ b/test/req.ip.test.js
@@ -58,7 +58,7 @@ describe('req.ip', function (){
       });
       newSocket.on('connect', function (){
         newSocket.get('/', function(resp) {
-          assert.equal(resp, '::ffff:127.0.0.1');
+          assert.equal(resp, '::1');
           return done();
         });
       });
@@ -115,7 +115,7 @@ describe('req.ip', function (){
       });
       newSocket.on('connect', function (){
         newSocket.get('/', function(resp) {
-          assert.equal(resp, '::ffff:127.0.0.1');
+          assert.equal(resp, '::1');
           return done();
         });
       });

--- a/test/req.ip.test.js
+++ b/test/req.ip.test.js
@@ -58,7 +58,7 @@ describe('req.ip', function (){
       });
       newSocket.on('connect', function (){
         newSocket.get('/', function(resp) {
-          assert.equal(resp, '::1');
+          assert.equal(resp, '::ffff:127.0.0.1');
           return done();
         });
       });
@@ -115,7 +115,7 @@ describe('req.ip', function (){
       });
       newSocket.on('connect', function (){
         newSocket.get('/', function(resp) {
-          assert.equal(resp, '::1');
+          assert.equal(resp, '::ffff:127.0.0.1');
           return done();
         });
       });

--- a/test/sails.sockets.test.js
+++ b/test/sails.sockets.test.js
@@ -238,8 +238,8 @@ describe('low-level socket methods:', function (){
             if (err) {return res.serverError(err);}
             var socket = sails.sockets.parseSocket(req.socket);
             // Return the list of rooms this socket is assigned to.
-            // Since socket.io v1.4, rooms is an object
-            var rooms = _.keys(socket.rooms);
+            // Since socket.io v3.x, rooms is an set
+            var rooms = Array.from(socket.rooms);
             return res.json(rooms);
           });
         });


### PR DESCRIPTION
Changes:
- Upgraded the socket.io dependency from `2.5.0` to `4.7.2`
- Upgraded the socket.io-redis dev dependency (`5.2.0` » `6.1.0`)
- Updated what/how socket.io methods are used.
- Updated the minimum version of `socket.io-redis` this hook is compatible with. The new minimum version is 6.0.0 (We will be publishing a new version of @sailshq/socket.io-redis that is supported in the new version of sails-hook-sockets)

